### PR TITLE
Fix - Tap in Discounts items

### DIFF
--- a/MLBusinessComponents.podspec
+++ b/MLBusinessComponents.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MLBusinessComponents"
-  s.version          = "1.7"
+  s.version          = "1.7.1"
   s.summary          = "MLBusinessComponents for iOS"
   s.homepage         = "https://www.mercadolibre.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/Source/Components/Discount/Internal/MLBusinessDiscountSingleItemView.swift
+++ b/Source/Components/Discount/Internal/MLBusinessDiscountSingleItemView.swift
@@ -105,21 +105,29 @@ extension MLBusinessDiscountSingleItemView {
             iconOverlay.centerXAnchor.constraint(equalTo: self.centerXAnchor)
             ])
 
-        let tapGesture = UILongPressGestureRecognizer(target: self, action: #selector(self.didTapOnButton))
-        tapGesture.minimumPressDuration = 0
+        let longTapGesture = UILongPressGestureRecognizer(target: self, action: #selector(self.didTapOnButton))
+        longTapGesture.minimumPressDuration = 0.2
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.callTapAction))
+        
+        self.addGestureRecognizer(longTapGesture)
         self.addGestureRecognizer(tapGesture)
     }
-
+    
     // MARK: Tap Selector
     @objc private func didTapOnButton(gesture: UITapGestureRecognizer) {
         if gesture.state == UITapGestureRecognizer.State.began {
             if self.discountSingleItem.deepLinkForItem() != nil {
                 self.backgroundColor = UIColor(red:0.96, green:0.96, blue:0.96, alpha:1.0)
             }
-            delegate?.didTap(item: discountSingleItem, index: itemIndex, section: itemSection)
         } else if gesture.state == UITapGestureRecognizer.State.ended {
             self.backgroundColor = .white
-        }
+            delegate?.didTap(item: discountSingleItem, index: itemIndex, section: itemSection)
+        } 
+    }
+    
+    @objc private func callTapAction(gesture: UITapGestureRecognizer) {
+        delegate?.didTap(item: discountSingleItem, index: itemIndex, section: itemSection)
     }
 
 }


### PR DESCRIPTION
## Descripción

Se cambia la lógica para el tap gesture en los items de discounts:

-  El longPressure tiene ahora un tiempo minimo y lanza el deeplink una vez se finaliza el tap. De esta manera se replica la acción que se tiene en Android y se **fixean** los casos en los que se lanza el deeplink y, al volver a la pantalla anterior, el fondo sigue estando de color gris ya que no se detectaba que la acción de pressure habia finalizado.

- Se agrega una tapAction normal para que se abra directamente deeplink en un tap "normal"

## Imágenes

WIP