### PR TITLE
Visual changes in labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.8.3
+🚀 1.8.3 🚀
+- Ajustes en label de DiscountBox
+- Ajustes en labels de Loyaty Ring View
+
 # v1.8.2
 🚀 1.8.2 🚀
 - Animated button shouldPop param.

--- a/Example/Example_BusinessComponents/MockData/LoyaltyRingData.swift
+++ b/Example/Example_BusinessComponents/MockData/LoyaltyRingData.swift
@@ -24,11 +24,11 @@ class LoyaltyRingData: NSObject, MLBusinessLoyaltyRingData {
     }
 
     func getTitle() -> String {
-        return "Ganaste 100 Puntos"
+        return "Sumaste 20 Mercado Puntos"
     }
 
     func getButtonTitle() -> String {
-        return "Mis beneficios"
+        return "Ver mis beneficios"
     }
 
     func getButtonDeepLink() -> String {

--- a/MLBusinessComponents.podspec
+++ b/MLBusinessComponents.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MLBusinessComponents"
-  s.version          = "1.8.2"
+  s.version          = "1.8.3"
   s.summary          = "MLBusinessComponents for iOS"
   s.homepage         = "https://www.mercadolibre.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/Source/Components/Discount/Internal/MLBusinessDiscountSingleItemView.swift
+++ b/Source/Components/Discount/Internal/MLBusinessDiscountSingleItemView.swift
@@ -65,7 +65,7 @@ extension MLBusinessDiscountSingleItemView {
         let itemTitle = UILabel()
         itemTitle.prepareForAutolayout(.clear)
         self.addSubview(itemTitle)
-        itemTitle.font = UIFont.ml_lightSystemFont(ofSize: UI.FontSize.XXS_FONT)
+        itemTitle.font = UIFont.ml_regularSystemFont(ofSize: UI.FontSize.XXS_FONT)
         itemTitle.applyBusinessLabelStyle()
         itemTitle.text = discountSingleItem.titleForItem()
         itemTitle.textAlignment = .center

--- a/Source/Components/Discount/MLBusinessDiscountBoxView.swift
+++ b/Source/Components/Discount/MLBusinessDiscountBoxView.swift
@@ -89,7 +89,7 @@ private extension MLBusinessDiscountBoxView {
         header.alignment = .fill
         
         header.addArrangedSubview(titleLabel)
-        titleLabel.font = UIFont.ml_semiboldSystemFont(ofSize: UI.FontSize.M_FONT)
+        titleLabel.font = UIFont.ml_semiboldSystemFont(ofSize: UI.FontSize.ML_FONT)
         titleLabel.applyBusinessLabelStyle()
         titleLabel.textAlignment = .center
         titleLabel.numberOfLines = 2

--- a/Source/Components/Loyalty/MLBusinessLoyaltyRingView.swift
+++ b/Source/Components/Loyalty/MLBusinessLoyaltyRingView.swift
@@ -57,7 +57,7 @@ extension MLBusinessLoyaltyRingView {
         titleLabel.prepareForAutolayout(.clear)
         titleLabel.numberOfLines = titleNumberOfLines
         titleLabel.text = viewData.getTitle()
-        titleLabel.font = UIFont.ml_semiboldSystemFont(ofSize: UI.FontSize.XS_FONT)
+        titleLabel.font = UIFont.ml_semiboldSystemFont(ofSize: UI.FontSize.S_FONT)
         titleLabel.applyBusinessLabelStyle()
         return titleLabel
     }
@@ -66,7 +66,7 @@ extension MLBusinessLoyaltyRingView {
         let button = UIButton()
         button.prepareForAutolayout(.clear)
         button.setTitle(viewData.getButtonTitle(), for: .normal)
-        button.titleLabel?.font = UIFont.ml_semiboldSystemFont(ofSize: UI.FontSize.M_FONT)
+        button.titleLabel?.font = UIFont.ml_semiboldSystemFont(ofSize: UI.FontSize.XS_FONT)
         button.setTitleColor(MLStyleSheetManager.styleSheet.secondaryColor, for: .normal)
         button.addTarget(self, action:  #selector(self.didTapOnButton), for: .touchUpInside)
         return button

--- a/Source/Core/UIConstants.swift
+++ b/Source/Core/UIConstants.swift
@@ -32,6 +32,7 @@ struct UI {
         static let XS_FONT: CGFloat = 14
         static let S_FONT: CGFloat = 16
         static let M_FONT: CGFloat = 18
+        static let ML_FONT: CGFloat = 20
         static let L_FONT: CGFloat = 22
     }
 


### PR DESCRIPTION
## Descripción

- Se ajustan labels en Loyalty Ring View, para estar a la par de lo pedido por UX
- Se ajusta titulo en Discount Box, se agranda de 18 a 20

## Tipo:

- [ ] Bugfix
- [X] Feature or Improvement

## Screenshots - Gifs
### Antes
<img width="339" alt="Captura de Pantalla 2020-02-17 a la(s) 16 29 37" src="https://user-images.githubusercontent.com/34245163/74681737-e9f63500-51a2-11ea-91e7-ace92be8856f.png">

### Despues
<img width="308" alt="Captura de Pantalla 2020-02-17 a la(s) 16 21 22" src="https://user-images.githubusercontent.com/34245163/74681603-908e0600-51a2-11ea-852c-a4fffc709b2a.png">
<img width="312" alt="Captura de Pantalla 2020-02-17 a la(s) 16 21 17" src="https://user-images.githubusercontent.com/34245163/74681606-92f06000-51a2-11ea-8a47-9f7dc8300f18.png">