### PR TITLE
Feature/fix reset animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-# v1.8.3
+# Sin Publicar (v1.8.4)
 🚀 1.8.3 🚀
-- Ajustes en label de DiscountBox
-- Ajustes en labels de Loyaty Ring View
+
+# v1.8.3
+🚀 Sin Publicar (1.8.4) 🚀
+- Fixing Animated button resetLoading function.
 
 # v1.8.2
 🚀 1.8.2 🚀

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Sin Publicar (v1.8.4)
-🚀 1.8.3 🚀
-
-# v1.8.3
 🚀 Sin Publicar (1.8.4) 🚀
 - Fixing Animated button resetLoading function.
+
+# v1.8.3
+🚀 1.8.3 🚀
+- Ajustes en label de DiscountBox
+- Ajustes en labels de Loyaty Ring View
 
 # v1.8.2
 🚀 1.8.2 🚀

--- a/Source/Components/AnimatedButton/MLBusinessAnimatedButton.swift
+++ b/Source/Components/AnimatedButton/MLBusinessAnimatedButton.swift
@@ -59,7 +59,7 @@ public class MLBusinessAnimatedButton: UIButton {
 
     @objc
     public func resetLoading() {
-        progressView?.reset()
+        progressView?.reset(view: self)
     }
 
     @objc

--- a/Source/Components/AnimatedButton/MLBusinessAnimatedButtonProgressView.swift
+++ b/Source/Components/AnimatedButton/MLBusinessAnimatedButtonProgressView.swift
@@ -79,8 +79,8 @@ final class MLBusinessAnimatedButtonProgressView: UIView {
         
     }
 
-    func reset() {
-        frame = CGRect(x: 0, y: 0, width: 0, height: frame.height)
+    func reset(view: UIView) {
+        if isDescendant(of: view) { removeFromSuperview() }
     }
 
     func finish(completion: @escaping () -> Void) {


### PR DESCRIPTION
## Descripción

Al resetear la animación del AnimatedButton el frame del ProgressView lo volviamos a 0 pero cada vez que haciamos un startAnimation estábamos agregando una nueva vista (progressView) al botón.

Lo que se hizo ahora es en el reset verificar si ya contiene una vista y en caso de ser así removerla para poder hacer el start nuevamente.

## Tipo:

- [x] Bugfix
- [ ] Feature or Improvement

## Screenshots - Gifs

![Loading-button](https://user-images.githubusercontent.com/45973176/79585758-a3d82780-80a6-11ea-862b-272965afc1fa.gif)

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [x] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [x] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
