### PR TITLE
Fixed Hybrid Carousel height on Store Cards. Fixed reuse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Sin Publicar
+- Fixes in Hybrid Carousel Component
+
 # v1.23.0
 🚀 1.23.0 🚀
 - Improvements in Sheet

--- a/Source/Components/Touchpoints/Types/HybridCarousel/Card/Types/Default/MLBusinessHybridCarouselCardDefaultView.swift
+++ b/Source/Components/Touchpoints/Types/HybridCarousel/Card/Types/Default/MLBusinessHybridCarouselCardDefaultView.swift
@@ -323,6 +323,7 @@ class MLBusinessHybridCarouselCardDefaultView: MLBusinessHybridCarouselCardTypeV
     override func prepareForReuse() {
         topImageImageView.image = nil
         topImageAccessoryImageView.image = nil
+        topImageAccessoryImageView.isHidden = true
         pillView.icon = nil
         middleVerticalStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         bottomHorizontalStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }

--- a/Source/Components/Touchpoints/Types/HybridCarousel/Container/MLBusinessHybridCarouselDataHandler.swift
+++ b/Source/Components/Touchpoints/Types/HybridCarousel/Container/MLBusinessHybridCarouselDataHandler.swift
@@ -81,10 +81,12 @@ class MLBusinessHybridCarouselDataHandler: NSObject {
             collectionViewHeight += hasMiddleTitle ? middleTitleLabelHeight : 0
             collectionViewHeight += hasMiddleSubtitle ? middleSubtitleLabelHeight : 0
             
-            if hasMiddleSubtitle {
-                collectionViewHeight += bottomSectionHeightWithSubtitle
-            } else {
-                collectionViewHeight += bottomSectionHeightWithoutSubtitle
+            if hasBottomTopLabel || hasBottomPrimaryLabel || hasBottomInfo {
+                if hasMiddleSubtitle {
+                    collectionViewHeight += bottomSectionHeightWithSubtitle
+                } else {
+                    collectionViewHeight += bottomSectionHeightWithoutSubtitle
+                }
             }
         }
         collectionViewHeight += spaceToBottom


### PR DESCRIPTION
## Descripción

Fixed Hybrid Carousel height on Store Cards. Fixed reuse.

## Tipo:

- [ ] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

![image](https://user-images.githubusercontent.com/49250268/92141709-30cb1580-ede9-11ea-8ccf-e7110693f67e.png)

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [x] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [x] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
