### PR TITLE
Default Values for Cover Carousel

### DIFF
--- a/Source/Components/Touchpoints/Types/CoverCarousel/Carousel/MLBusinessCoverCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Carousel/MLBusinessCoverCarouselView.swift
@@ -122,7 +122,7 @@ public class MLBusinessCoverCarouselView: UIView {
     }
     
     private func setLayoutAnimators(from model: MLBusinessCoverCarouselModel) {
-        let shouldAnimateAlpha = model.alphaAnimation ?? true
+        let shouldAnimateAlpha = model.alphaAnimation ?? false
         let shouldAnimateScale = model.scaleAnimation ?? false
         
         var animators: [MLBusinessLayoutAttributeAnimator] = []
@@ -153,7 +153,7 @@ extension MLBusinessCoverCarouselView: UICollectionViewDataSource {
         let item = items[indexPath.row]
         cell.imageProvider = imageProvider
         cell.update(with: item)
-        cell.animatesWhenPressed = model?.pressAnimation ?? true
+        cell.animatesWhenPressed = model?.pressAnimation ?? false
         
         return cell
     }


### PR DESCRIPTION
## Descripción

Este **PR** simplemente corrige los valores por default de animación del alpha de las cards en el carousel, y de la animación de tap en las mismas, para el caso en que dichas propiedades vengan como `nil` en el modelo.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
