### PR TITLE
Cover Carousel Fixes

### DIFF
--- a/Example/Example_BusinessComponents.xcodeproj/project.pbxproj
+++ b/Example/Example_BusinessComponents.xcodeproj/project.pbxproj
@@ -156,7 +156,6 @@
 				23EE405F2326B50B001322EC /* Frameworks */,
 				23EE40602326B50B001322EC /* Resources */,
 				FA5FCEAD3211C896ECF15993 /* [CP] Embed Pods Frameworks */,
-				6CEF88A4CDB2621527989AF0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -235,23 +234,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6CEF88A4CDB2621527989AF0 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Example_BusinessComponents/Pods-Example_BusinessComponents-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Example_BusinessComponents/Pods-Example_BusinessComponents-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example_BusinessComponents/Pods-Example_BusinessComponents-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FA5FCEAD3211C896ECF15993 /* [CP] Embed Pods Frameworks */ = {

--- a/Example/Example_BusinessComponents/MockData/CoverCarouselData.swift
+++ b/Example/Example_BusinessComponents/MockData/CoverCarouselData.swift
@@ -26,18 +26,55 @@ class CoverCarouselData: NSObject, MLBusinessTouchpointsData {
         let burger = "https://cdn2.cocinadelirante.com/sites/default/files/styles/gallerie/public/images/2018/05/hamburguesa-con-fondue-receta.jpg"
         let pizza = "https://gift-static.kxscdn.com/img/pizza-napolitana/pizza-napolitana.jpg"
 
-        let cardModels = [MLBusinessCoverCarouselItemModel(cover: burger, description: RowData().asModel()),
-                          MLBusinessCoverCarouselItemModel(cover: pizza, description: RowData().asModel()),
-                          MLBusinessCoverCarouselItemModel(cover: burger, description: RowData().asModel()),
-                          MLBusinessCoverCarouselItemModel(cover: pizza, description: RowData().asModel()),
-                          MLBusinessCoverCarouselItemModel(cover: pizza, description: RowData().asModel())
+        let cardModels = [getCoverCarouselModel(from: burger, and: RowData().asModel()),
+                          getCoverCarouselModel(from: pizza, and: RowData().asModel()),
+                          getCoverCarouselModel(from: burger, and: RowData().asModel()),
+                          getCoverCarouselModel(from: pizza, and: RowData().asModel()),
+                          getCoverCarouselModel(from: pizza, and: RowData().asModel())
         ]
 
         let carouselModel = MLBusinessCoverCarouselModel(items: cardModels,
-                                                         alphaAnimation: nil,
-                                                         scaleAnimation: nil,
-                                                         pressAnimation: nil)
-        
+                                                         carouselAnimation: nil)
         return carouselModel.asDictionary()
+    }
+    
+    private func getCoverCarouselModel(from cover: String, and rowData: MLBusinessRowData) -> MLBusinessCoverCarouselItemModel {
+        let content = MLBusinessCoverCarouselItemContentModel(cover: cover,
+                                                              leftImage: rowData.getLeftImage(),
+                                                              leftImageAccessory: rowData.getLeftImageAccessory(),
+                                                              mainTitle: rowData.getMainTitle(),
+                                                              mainSubtitle: rowData.getMainSubtitle(),
+                                                              mainDescription: getMainDescription(from: rowData),
+                                                              mainSecondaryDescription: rowData.getMainSecondaryDescription?(),
+                                                              rightPrimaryLabel: rowData.getRightPrimaryLabel(),
+                                                              rightSecondaryLabel: rowData.getRightSecondaryLabel(),
+                                                              rightMiddleLabel: rowData.getRightMiddleLabel(),
+                                                              rightTopLabel: rowData.getRightTopLabel(),
+                                                              rightLabelStatus: rowData.getRightLabelStatus(),
+                                                              rightBottomInfo: getRightBottomInfo(from: rowData))
+        
+        return MLBusinessCoverCarouselItemModel(content: content,
+                                                link: nil,
+                                                tracking: nil)
+    }
+    
+    private func getMainDescription(from rowData: MLBusinessRowData) -> [MLBusinessRowMainDescription] {
+        guard let mainDescription = rowData.getMainDescription() else { return [] }
+        
+        return mainDescription.map({
+            MLBusinessRowMainDescription(type: $0.getType(), content: $0.getContent(), color: $0.getColor())
+        })
+    }
+    
+    private func getRightBottomInfo(from rowData: MLBusinessRowData) -> MLBusinessRowRightBottomInfo {
+        let textColor = rowData.getRightBottomInfo()?.getFormat()?.getTextColor() ?? "#000000"
+        let backgroundColor = rowData.getRightBottomInfo()?.getFormat()?.getBackgroundColor() ?? "#ffffff"
+        
+        let format = MLBusinessRowRightBottomInfoFormat(textColor: textColor,
+                                                        backgroundColor: backgroundColor)
+        
+        return MLBusinessRowRightBottomInfo(icon: rowData.getRightBottomInfo()?.getIcon(),
+                                                           label: rowData.getRightBottomInfo()?.getLabel(),
+                                                           format: format)
     }
 }

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemContentModelMapper.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemContentModelMapper.swift
@@ -1,0 +1,31 @@
+//
+//  MLBusinessCoverCarouselItemContentModelMapper.swift
+//  MLBusinessComponents
+//
+//  Created by Gaston Maspero on 18/11/2020.
+//
+
+import Foundation
+
+protocol MLBusinessCoverCarouselItemContentModelMapperProtocol {
+    func map(from model: MLBusinessCoverCarouselItemContentModel) -> MLBusinessMultipleRowItemModel
+}
+
+class MLBusinessCoverCarouselItemContentModelMapper: MLBusinessCoverCarouselItemContentModelMapperProtocol {
+    func map(from model: MLBusinessCoverCarouselItemContentModel) -> MLBusinessMultipleRowItemModel {
+        return MLBusinessMultipleRowItemModel(leftImage: model.leftImage,
+                                              leftImageAccessory: model.leftImageAccessory,
+                                              mainTitle: model.mainTitle,
+                                              mainSubtitle: model.mainSubtitle,
+                                              mainDescription: model.mainDescription,
+                                              mainSecondaryDescription: model.mainSecondaryDescription,
+                                              rightPrimaryLabel: model.rightPrimaryLabel,
+                                              rightSecondaryLabel: model.rightSecondaryLabel,
+                                              rightMiddleLabel: model.rightMiddleLabel,
+                                              rightTopLabel: model.rightTopLabel,
+                                              rightLabelStatus: model.rightLabelStatus,
+                                              rightBottomInfo: model.rightBottomInfo,
+                                              link: nil,
+                                              tracking: nil)
+    }
+}

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemModel.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemModel.swift
@@ -19,6 +19,14 @@ public struct MLBusinessCoverCarouselItemModel: Codable {
         self.link = link
         self.tracking = tracking
     }
+    
+    public func getTrackingId() -> String? {
+        return trackingId
+    }
+    
+    public func getEventData() -> [String : Any]? {
+        return eventData?.rawValue
+    }
 }
 
 extension MLBusinessCoverCarouselItemModel: Trackable {

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemModel.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemModel.swift
@@ -8,21 +8,69 @@
 import Foundation
 
 public struct MLBusinessCoverCarouselItemModel: Codable {
-    public let cover: String?
-    public let description: MLBusinessMultipleRowItemModel?
-
-    public init(cover: String?, description: MLBusinessMultipleRowItemModel?) {
-        self.cover = cover
-        self.description = description
+    public let content: MLBusinessCoverCarouselItemContentModel?
+    public let link: String?
+    public let tracking: MLBusinessItemModelTracking?
+    
+    public init(content: MLBusinessCoverCarouselItemContentModel?,
+                link: String?,
+                tracking: MLBusinessItemModelTracking?) {
+        self.content = content
+        self.link = link
+        self.tracking = tracking
     }
 }
 
 extension MLBusinessCoverCarouselItemModel: Trackable {
     var trackingId: String? {
-        return description?.trackingId
+        return tracking?.trackingId
     }
-
+    
     var eventData: MLBusinessCodableDictionary? {
-        return description?.eventData
+        return tracking?.eventData
+    }
+}
+
+public struct MLBusinessCoverCarouselItemContentModel: Codable {
+    public let cover: String?
+    public let leftImage: String?
+    public let leftImageAccessory: String?
+    public let mainTitle: String
+    public let mainSubtitle: String?
+    public let mainDescription: [MLBusinessRowMainDescription]?
+    public let mainSecondaryDescription: [MLBusinessMultipleDescriptionModel]?
+    public let rightPrimaryLabel: String?
+    public let rightSecondaryLabel: String?
+    public let rightMiddleLabel: String?
+    public let rightTopLabel: String?
+    public let rightLabelStatus: String?
+    public let rightBottomInfo: MLBusinessRowRightBottomInfo?
+    
+    public init(cover: String?,
+                leftImage: String?,
+                leftImageAccessory: String?,
+                mainTitle: String,
+                mainSubtitle: String?,
+                mainDescription: [MLBusinessRowMainDescription]?,
+                mainSecondaryDescription: [MLBusinessMultipleDescriptionModel]?,
+                rightPrimaryLabel: String?,
+                rightSecondaryLabel: String?,
+                rightMiddleLabel: String?,
+                rightTopLabel: String?,
+                rightLabelStatus: String?,
+                rightBottomInfo: MLBusinessRowRightBottomInfo?) {
+        self.cover = cover
+        self.leftImage = leftImage
+        self.leftImageAccessory = leftImageAccessory
+        self.mainTitle = mainTitle
+        self.mainSubtitle = mainSubtitle
+        self.mainDescription = mainDescription
+        self.mainSecondaryDescription = mainSecondaryDescription
+        self.rightPrimaryLabel = rightPrimaryLabel
+        self.rightSecondaryLabel = rightSecondaryLabel
+        self.rightMiddleLabel = rightMiddleLabel
+        self.rightTopLabel = rightTopLabel
+        self.rightLabelStatus = rightLabelStatus
+        self.rightBottomInfo = rightBottomInfo
     }
 }

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemView.swift
@@ -9,7 +9,8 @@ import UIKit
 import MLUI
 
 public class MLBusinessCoverCarouselItemView: UIView {
-    private let coverHeight: CGFloat
+    static let coverHeight: CGFloat = 100
+    private let mapper: MLBusinessCoverCarouselItemContentModelMapperProtocol
     
     private lazy var alphaOverlayView: UIView = {
         let view = UIView()
@@ -38,9 +39,9 @@ public class MLBusinessCoverCarouselItemView: UIView {
     
     var imageProvider: MLBusinessImageProvider
     
-    public init(with imageProvider: MLBusinessImageProvider? = nil, coverHeight: CGFloat = 100) {
+    public init(with imageProvider: MLBusinessImageProvider? = nil) {
         self.imageProvider = imageProvider ?? MLBusinessURLImageProvider()
-        self.coverHeight = coverHeight
+        self.mapper = MLBusinessCoverCarouselItemContentModelMapper()
             
         super.init(frame: .zero)
         
@@ -52,17 +53,17 @@ public class MLBusinessCoverCarouselItemView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public func update(with item: MLBusinessCoverCarouselItemModel) {
+    public func update(with item: MLBusinessCoverCarouselItemContentModel) {
         clear()
+        
         if let cover = item.cover {
             imageProvider.getImage(key: cover) { [weak self] image in
                 self?.coverImageView.image = image
             }
         }
         
-        if let description = item.description {
-            rowView.update(with: description)
-        }
+        let rowModel = mapper.map(from: item)
+        rowView.update(with: rowModel)
     }
     
     public func setHighlighted(_ highlighted: Bool) {
@@ -72,6 +73,13 @@ public class MLBusinessCoverCarouselItemView: UIView {
     public func clear() {
         coverImageView.image = nil
         rowView.prepareForReuse()
+    }
+    
+    static func height(for model: MLBusinessCoverCarouselItemContentModel) -> CGFloat {
+        let isRowSmall = model.mainSecondaryDescription?.isEmpty ?? true
+        let rowHeight: CGFloat = isRowSmall ? 96 : 114
+        
+        return coverHeight + rowHeight
     }
     
     private func setupView() {
@@ -96,7 +104,7 @@ public class MLBusinessCoverCarouselItemView: UIView {
             coverImageView.topAnchor.constraint(equalTo: topAnchor),
             coverImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
             coverImageView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            coverImageView.heightAnchor.constraint(equalToConstant: coverHeight)
+            coverImageView.heightAnchor.constraint(equalToConstant: MLBusinessCoverCarouselItemView.coverHeight)
         ])
         
         NSLayoutConstraint.activate([

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselViewCell.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselViewCell.swift
@@ -70,9 +70,7 @@ class MLBusinessCoverCarouselViewCell: UICollectionViewCell {
         itemView.clear()
     }
     
-    func update(with content: MLBusinessCoverCarouselItemContentModel?) {
-        guard let content = content else { return }
-        
+    func update(with content: MLBusinessCoverCarouselItemContentModel) {
         itemView.update(with: content)
     }
 

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselViewCell.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselViewCell.swift
@@ -70,7 +70,9 @@ class MLBusinessCoverCarouselViewCell: UICollectionViewCell {
         itemView.clear()
     }
     
-    func update(with content: MLBusinessCoverCarouselItemModel) {
+    func update(with content: MLBusinessCoverCarouselItemContentModel?) {
+        guard let content = content else { return }
+        
         itemView.update(with: content)
     }
 

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Carousel/MLBusinessCoverCarouselModel.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Carousel/MLBusinessCoverCarouselModel.swift
@@ -9,23 +9,30 @@ import Foundation
 
 public struct MLBusinessCoverCarouselModel: Codable {
     public let items: [MLBusinessCoverCarouselItemModel]
-    public let alphaAnimation: Bool?
-    public let scaleAnimation: Bool?
-    public let pressAnimation: Bool?
+    public let carouselAnimation: MLBusinessCoverCarouselAnimation?
     
-    public init(items: [MLBusinessCoverCarouselItemModel],
-                alphaAnimation: Bool?,
-                scaleAnimation: Bool?,
-                pressAnimation: Bool?) {
+    public init(items: [MLBusinessCoverCarouselItemModel], carouselAnimation: MLBusinessCoverCarouselAnimation?) {
         self.items = items
-        self.alphaAnimation = alphaAnimation
-        self.scaleAnimation = scaleAnimation
-        self.pressAnimation = pressAnimation
+        self.carouselAnimation = carouselAnimation
     }
 }
 
 extension MLBusinessCoverCarouselModel: ComponentTrackable {
     func getTrackables() -> [Trackable]? {
         return items
+    }
+}
+
+public struct MLBusinessCoverCarouselAnimation: Codable {
+    public let alphaAnimation: Bool?
+    public let scaleAnimation: Bool?
+    public let pressAnimation: Bool?
+    
+    public init(alphaAnimation: Bool?,
+                scaleAnimation: Bool?,
+                pressAnimation: Bool?) {
+        self.alphaAnimation = alphaAnimation
+        self.scaleAnimation = scaleAnimation
+        self.pressAnimation = pressAnimation
     }
 }

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Carousel/MLBusinessCoverCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Carousel/MLBusinessCoverCarouselView.swift
@@ -143,13 +143,14 @@ extension MLBusinessCoverCarouselView: UICollectionViewDataSource {
     }
     
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView
-            .dequeueReusableCell(withReuseIdentifier: MLBusinessCoverCarouselViewCell.reuseIdentifier,
-                                 for: indexPath) as? MLBusinessCoverCarouselViewCell else {
-                                    return MLBusinessCoverCarouselViewCell() }
-        let item = items[indexPath.row]
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MLBusinessCoverCarouselViewCell.reuseIdentifier,
+                                                            for: indexPath) as? MLBusinessCoverCarouselViewCell,
+              let content = items[indexPath.row].content else {
+                                    return MLBusinessCoverCarouselViewCell()
+        }
+        
         cell.imageProvider = imageProvider
-        cell.update(with: item.content)
+        cell.update(with: content)
         cell.animatesWhenPressed = model?.carouselAnimation?.pressAnimation ?? false
         
         return cell

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Carousel/MLBusinessCoverCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Carousel/MLBusinessCoverCarouselView.swift
@@ -84,13 +84,13 @@ public class MLBusinessCoverCarouselView: UIView {
     public func update(with model: MLBusinessCoverCarouselModel) {
         self.model = model
         
-        setLayoutAnimators(from: model)
+        setLayoutAnimators(from: model.carouselAnimation)
         collectionViewHeightConstraint?.constant = getMaxItemHeight(for: model)
         collectionView.reloadData()
     }
     
     func getMaxItemHeight(for model: MLBusinessCoverCarouselModel?) -> CGFloat {
-        return model?.items.map({ getViewHeight(for: $0) }).max() ?? 0
+        return model?.items.map({ getViewHeight(for: $0.content) }).max() ?? 0
     }
     
     private func setupView() {
@@ -111,19 +111,16 @@ public class MLBusinessCoverCarouselView: UIView {
         ])
     }
     
-    private func getViewHeight(for model: MLBusinessCoverCarouselItemModel) -> CGFloat {
-        let view = MLBusinessCoverCarouselItemView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width - 32.0).isActive = true
-        view.update(with: model)
-        view.setNeedsLayout()
-        view.layoutIfNeeded()
-        return view.frame.height
+    private func getViewHeight(for model: MLBusinessCoverCarouselItemContentModel?) -> CGFloat {
+        guard let model = model else { return 0 }
+        
+        return MLBusinessCoverCarouselItemView.height(for: model)
     }
     
-    private func setLayoutAnimators(from model: MLBusinessCoverCarouselModel) {
-        let shouldAnimateAlpha = model.alphaAnimation ?? false
-        let shouldAnimateScale = model.scaleAnimation ?? false
+    private func setLayoutAnimators(from model: MLBusinessCoverCarouselAnimation?) {
+        let shouldAnimateAlpha = model?.alphaAnimation ?? false
+        let shouldAnimateScale = model?.scaleAnimation ?? false
+
         
         var animators: [MLBusinessLayoutAttributeAnimator] = []
         
@@ -152,8 +149,8 @@ extension MLBusinessCoverCarouselView: UICollectionViewDataSource {
                                     return MLBusinessCoverCarouselViewCell() }
         let item = items[indexPath.row]
         cell.imageProvider = imageProvider
-        cell.update(with: item)
-        cell.animatesWhenPressed = model?.pressAnimation ?? false
+        cell.update(with: item.content)
+        cell.animatesWhenPressed = model?.carouselAnimation?.pressAnimation ?? false
         
         return cell
     }

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Touchpoint/MLBusinessTouchpointsCoverCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Touchpoint/MLBusinessTouchpointsCoverCarouselView.swift
@@ -73,7 +73,7 @@ class MLBusinessTouchpointsCoverCarouselView: MLBusinessTouchpointsBaseView {
 
 extension MLBusinessTouchpointsCoverCarouselView: MLBusinessCoverCarouselViewDelegate {
     func coverCarouselView(_: MLBusinessCoverCarouselView, didSelect item: MLBusinessCoverCarouselItemModel, at index: Int) {
-        guard let link = item.description?.getLink(), let trackingId = item.description?.trackingId else { return }
+        guard let link = item.link, let trackingId = item.trackingId else { return }
         
         delegate?.trackTap(with: index, deeplink: link, trackingId: trackingId)
     }


### PR DESCRIPTION
## Descripción

Este **PR** agrega:
- Workaround para el cómputo de la altura de una `HybridRow`, necesario para resolver la altura de las cards del `CoverCarousel`. 
- Reestructuración de los modelos para el `CoverCarousel`.

## Tipo:

- [x] Bugfix
- [ ] Feature or Improvement

## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [x] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [x] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
