### PR TITLE
Expose Image Provider in Row

### DIFF
--- a/Source/Components/MultipleDescription/MLBusinessMultipleDescriptionView.swift
+++ b/Source/Components/MultipleDescription/MLBusinessMultipleDescriptionView.swift
@@ -18,7 +18,7 @@ public class MLBusinessMultipleDescriptionView: UIView {
         return stackView
     }()
     
-    private var imageProvider: MLBusinessImageProvider
+    var imageProvider: MLBusinessImageProvider
 
     @available(*, unavailable)
     required init?(coder _: NSCoder) {

--- a/Source/Components/Row/MLBusinessRowView.swift
+++ b/Source/Components/Row/MLBusinessRowView.swift
@@ -152,7 +152,14 @@ public class MLBusinessRowView: UIView {
         return rightBottomInfo
     }()
 
-    private var imageProvider: MLBusinessImageProvider
+    var imageProvider: MLBusinessImageProvider {
+        didSet {
+            mainDescriptionView.imageProvider = imageProvider
+            mainSecondaryDescriptionView.imageProvider = imageProvider
+            
+        }
+    }
+    
     private let mainDescriptionView: MLBusinessMultipleDescriptionView
     private let mainSecondaryDescriptionView: MLBusinessMultipleDescriptionView
     private var rightStackViewWidthConstraint: NSLayoutConstraint?

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemView.swift
@@ -37,7 +37,11 @@ public class MLBusinessCoverCarouselItemView: UIView {
         return MLBusinessRowView()
     }()
     
-    var imageProvider: MLBusinessImageProvider
+    var imageProvider: MLBusinessImageProvider {
+        didSet {
+            rowView.imageProvider = imageProvider
+        }
+    }
     
     public init(with imageProvider: MLBusinessImageProvider? = nil) {
         self.imageProvider = imageProvider ?? MLBusinessURLImageProvider()


### PR DESCRIPTION
## Descripción

Este **PR** simplemente expone a la property `imageProvider` del componente _Row_. De esta manera quedan seteables desde afuera.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
