### PR TITLE
Added hybrid row title and subtitle grayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Sin Publicar
+- Added hybrid row title and subtitle grayed from BE
+
 # v1.30.0
 🚀 1.30.0 🚀
 - Static frameworks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Sin Publicar
-- Added hybrid row title and subtitle grayed from BE
+- Added closed status support to title and subtile on Hybrid Row
 
 # v1.30.0
 🚀 1.30.0 🚀

--- a/Example/Example_BusinessComponents/MockData/RowData.swift
+++ b/Example/Example_BusinessComponents/MockData/RowData.swift
@@ -32,10 +32,10 @@ class RowData: NSObject, MLBusinessRowData {
     
     func getMainDescription() -> [MLBusinessRowMainDescriptionData]? {
         return [RowMainDescriptionData(type: "image", content: "https://i.ibb.co/2KcdLdy/16-px.png", color: "#454545"),
-                RowMainDescriptionData(type: "text", content: "598m", color: "#454545"),
-                RowMainDescriptionData(type: "text", content: " · ", color: "#454545"),
-                RowMainDescriptionData(type: "image", content: "https://i.ibb.co/prSV6dY/estrella-android.png", color: "#454545"),
-                RowMainDescriptionData(type: "text", content: "4.3 (24)", color: "#454545"),]
+                RowMainDescriptionData(type: "text", content: "598m", color: "#999999"),
+                RowMainDescriptionData(type: "text", content: " · ", color: "#999999"),
+                RowMainDescriptionData(type: "image", content: "https://i.ibb.co/prSV6dY/estrella-android.png", color: "#999999"),
+                RowMainDescriptionData(type: "text", content: "4.3 (24)", color: "#999999"),]
     }
     
     func getMainSecondaryDescription() -> [MLBusinessMultipleDescriptionModel]? {

--- a/Example/Example_BusinessComponents/MockData/RowData.swift
+++ b/Example/Example_BusinessComponents/MockData/RowData.swift
@@ -78,6 +78,10 @@ class RowData: NSObject, MLBusinessRowData {
     func getLink() -> String? {
         return "mercadopago://scanqr"
     }
+    
+    func getMainTitleStatus() -> String? {
+        return "CLOSED"
+    }
 }
 
 extension RowData {

--- a/Example/Example_BusinessComponents/MockData/RowData.swift
+++ b/Example/Example_BusinessComponents/MockData/RowData.swift
@@ -31,11 +31,11 @@ class RowData: NSObject, MLBusinessRowData {
     }
     
     func getMainDescription() -> [MLBusinessRowMainDescriptionData]? {
-        return [RowMainDescriptionData(type: "image", content: "https://i.ibb.co/2KcdLdy/16-px.png", color: "#454545"),
-                RowMainDescriptionData(type: "text", content: "598m", color: "#999999"),
-                RowMainDescriptionData(type: "text", content: " · ", color: "#999999"),
-                RowMainDescriptionData(type: "image", content: "https://i.ibb.co/prSV6dY/estrella-android.png", color: "#999999"),
-                RowMainDescriptionData(type: "text", content: "4.3 (24)", color: "#999999"),]
+        return [RowMainDescriptionData(type: "image", content: "https://i.ibb.co/2KcdLdy/16-px.png", color: "#737373"),
+                RowMainDescriptionData(type: "text", content: "598m", color: "#737373"),
+                RowMainDescriptionData(type: "text", content: " · ", color: "#737373"),
+                RowMainDescriptionData(type: "image", content: "https://i.ibb.co/prSV6dY/estrella-android.png", color: "#737373"),
+                RowMainDescriptionData(type: "text", content: "4.3 (24)", color: "#737373"),]
     }
     
     func getMainSecondaryDescription() -> [MLBusinessMultipleDescriptionModel]? {

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org'
 
 platform :ios, '10.0'
 use_frameworks!

--- a/Source/Components/Row/MLBusinessRowData.swift
+++ b/Source/Components/Row/MLBusinessRowData.swift
@@ -23,6 +23,7 @@ import Foundation
     @objc func getRightLabelStatus() -> String?
     @objc func getRightBottomInfo() -> MLBusinessRowRightBottomInfoData?
     @objc func getLink() -> String?
+    @objc optional func getMainTitleStatus() -> String?
 }
 
 @objc public protocol MLBusinessRowMainDescriptionData: NSObjectProtocol {

--- a/Source/Components/Row/MLBusinessRowView.swift
+++ b/Source/Components/Row/MLBusinessRowView.swift
@@ -157,6 +157,12 @@ public class MLBusinessRowView: UIView {
         rightBottomInfo.translatesAutoresizingMaskIntoConstraints = false
         return rightBottomInfo
     }()
+    
+    private let blockedColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
+    private let closedBlackColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
+    private let closedGreyColor = MLStyleSheetManager.styleSheet.greyColor.withAlphaComponent(0.4)
+    private let blackColor = MLStyleSheetManager.styleSheet.blackColor
+    private let greyColor = MLStyleSheetManager.styleSheet.greyColor
 
     var imageProvider: MLBusinessImageProvider {
         didSet {
@@ -285,6 +291,8 @@ public class MLBusinessRowView: UIView {
         leftImageAccessoryImageView.image = nil
         rightBottomInfoPill.icon = nil
         rightStackViewWidthConstraint?.isActive = false
+        mainTitleLabel.textColor = blackColor
+        mainSubtitleLabel.textColor = blackColor
     }
     
     private func createLeftSection(with content: MLBusinessRowData) {
@@ -365,8 +373,8 @@ public class MLBusinessRowView: UIView {
     
     private func setMainTitleStatus(with status: String?) {
         guard let status = status, status.lowercased() == "closed" else { return }
-        mainTitleLabel.textColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
-        mainSubtitleLabel.textColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
+        mainTitleLabel.textColor = closedBlackColor
+        mainSubtitleLabel.textColor = closedBlackColor
     }
     
     private func createRightTopLabel(with text: String?) {
@@ -426,21 +434,16 @@ public class MLBusinessRowView: UIView {
     
     private func setRightLabelStatus(with rightLabelStatus: String?) {
         if let rightLabelStatus = rightLabelStatus, rightLabelStatus.lowercased() == "blocked" {
-            let blockedColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
             rightPrimaryLabel.textColor = blockedColor
             rightSecondaryLabel.textColor = blockedColor
             rightBottomInfoPill.alpha = 1
         } else if let rightLabelStatus = rightLabelStatus, rightLabelStatus.lowercased() == "closed" {
-            let closedBlackColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
-            let closedGreyColor = MLStyleSheetManager.styleSheet.greyColor.withAlphaComponent(0.4)
             rightTopLabel.textColor = closedBlackColor
             rightPrimaryLabel.textColor = closedBlackColor
             rightSecondaryLabel.textColor = closedBlackColor
             rightMiddleLabel.textColor = closedGreyColor
             rightBottomInfoPill.alpha = 0.4
         } else {
-            let blackColor = MLStyleSheetManager.styleSheet.blackColor
-            let greyColor = MLStyleSheetManager.styleSheet.greyColor
             rightTopLabel.textColor = blackColor
             rightPrimaryLabel.textColor = blackColor
             rightSecondaryLabel.textColor = blackColor

--- a/Source/Components/Row/MLBusinessRowView.swift
+++ b/Source/Components/Row/MLBusinessRowView.swift
@@ -159,7 +159,7 @@ public class MLBusinessRowView: UIView {
     }()
     
     private let blockedColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
-    private let closedBlackColor = "#737373".hexaToUIColor()
+    private let closedBlackColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
     private let closedGreyColor = MLStyleSheetManager.styleSheet.greyColor.withAlphaComponent(0.4)
     private let blackColor = MLStyleSheetManager.styleSheet.blackColor
     private let greyColor = MLStyleSheetManager.styleSheet.greyColor

--- a/Source/Components/Row/MLBusinessRowView.swift
+++ b/Source/Components/Row/MLBusinessRowView.swift
@@ -294,11 +294,12 @@ public class MLBusinessRowView: UIView {
     }
     
     private func createMainSection(with content: MLBusinessRowData) {
-        createMainTitle(with: content.getMainTitle(), titleStatus: content.getMainTitleStatus?())
-        createMainSubtitle(with: content.getMainSubtitle(), subtitleStatus: content.getMainTitleStatus?())
+        createMainTitle(with: content.getMainTitle())
+        createMainSubtitle(with: content.getMainSubtitle())
         createMainDescription(with: content.getMainDescription())
         createMainSecondaryDescription(with: content.getMainSecondaryDescription?())
         createStatusDescription(with: content.getStatusDescription?())
+        setMainTitleStatus(with: content.getMainTitleStatus?())
     }
     
     private func createRightSection(with content: MLBusinessRowData) {
@@ -330,24 +331,14 @@ public class MLBusinessRowView: UIView {
         }
     }
     
-    private func createMainTitle(with text: String?, titleStatus: String?) {
+    private func createMainTitle(with text: String?) {
         guard let mainTitleText = text else { return }
-        
-        if let titleStatus = titleStatus, titleStatus.lowercased() == "closed" {
-            mainTitleLabel.textColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
-        }
-        
         mainTitleLabel.text = mainTitleText
         mainStackView.addArrangedSubview(mainTitleLabel)
     }
     
-    private func createMainSubtitle(with text: String?, subtitleStatus: String?) {
+    private func createMainSubtitle(with text: String?) {
         guard let mainSubtitleText = text else { return }
-        
-        if let subtitleStatus = subtitleStatus, subtitleStatus.lowercased() == "closed" {
-            mainSubtitleLabel.textColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
-        }
-        
         mainSubtitleLabel.text = mainSubtitleText
         mainStackView.addArrangedSubview(mainSubtitleView)
     }
@@ -370,6 +361,12 @@ public class MLBusinessRowView: UIView {
         guard let model = statusDescriptionModel, model.count > 0 else { return }
         statusDescriptionView.update(with: model)
         mainStackView.addArrangedSubview(statusDescriptionContainerView)
+    }
+    
+    private func setMainTitleStatus(with status: String?) {
+        guard let status = status, status.lowercased() == "closed" else { return }
+        mainTitleLabel.textColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
+        mainSubtitleLabel.textColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
     }
     
     private func createRightTopLabel(with text: String?) {

--- a/Source/Components/Row/MLBusinessRowView.swift
+++ b/Source/Components/Row/MLBusinessRowView.swift
@@ -159,7 +159,7 @@ public class MLBusinessRowView: UIView {
     }()
     
     private let blockedColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
-    private let closedBlackColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
+    private let closedBlackColor = "#737373".hexaToUIColor()
     private let closedGreyColor = MLStyleSheetManager.styleSheet.greyColor.withAlphaComponent(0.4)
     private let blackColor = MLStyleSheetManager.styleSheet.blackColor
     private let greyColor = MLStyleSheetManager.styleSheet.greyColor

--- a/Source/Components/Row/MLBusinessRowView.swift
+++ b/Source/Components/Row/MLBusinessRowView.swift
@@ -294,8 +294,8 @@ public class MLBusinessRowView: UIView {
     }
     
     private func createMainSection(with content: MLBusinessRowData) {
-        createMainTitle(with: content.getMainTitle())
-        createMainSubtitle(with: content.getMainSubtitle())
+        createMainTitle(with: content.getMainTitle(), titleStatus: content.getMainTitleStatus?())
+        createMainSubtitle(with: content.getMainSubtitle(), subtitleStatus: content.getMainTitleStatus?())
         createMainDescription(with: content.getMainDescription())
         createMainSecondaryDescription(with: content.getMainSecondaryDescription?())
         createStatusDescription(with: content.getStatusDescription?())
@@ -330,14 +330,24 @@ public class MLBusinessRowView: UIView {
         }
     }
     
-    private func createMainTitle(with text: String?) {
+    private func createMainTitle(with text: String?, titleStatus: String?) {
         guard let mainTitleText = text else { return }
+        
+        if let titleStatus = titleStatus, titleStatus.lowercased() == "closed" {
+            mainTitleLabel.textColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
+        }
+        
         mainTitleLabel.text = mainTitleText
         mainStackView.addArrangedSubview(mainTitleLabel)
     }
     
-    private func createMainSubtitle(with text: String?) {
+    private func createMainSubtitle(with text: String?, subtitleStatus: String?) {
         guard let mainSubtitleText = text else { return }
+        
+        if let subtitleStatus = subtitleStatus, subtitleStatus.lowercased() == "closed" {
+            mainSubtitleLabel.textColor = MLStyleSheetManager.styleSheet.blackColor.withAlphaComponent(0.4)
+        }
+        
         mainSubtitleLabel.text = mainSubtitleText
         mainStackView.addArrangedSubview(mainSubtitleView)
     }

--- a/Source/Components/Row/MLBusinessRowView.swift
+++ b/Source/Components/Row/MLBusinessRowView.swift
@@ -291,8 +291,6 @@ public class MLBusinessRowView: UIView {
         leftImageAccessoryImageView.image = nil
         rightBottomInfoPill.icon = nil
         rightStackViewWidthConstraint?.isActive = false
-        mainTitleLabel.textColor = blackColor
-        mainSubtitleLabel.textColor = blackColor
     }
     
     private func createLeftSection(with content: MLBusinessRowData) {
@@ -372,7 +370,11 @@ public class MLBusinessRowView: UIView {
     }
     
     private func setMainTitleStatus(with status: String?) {
-        guard let status = status, status.lowercased() == "closed" else { return }
+        guard let status = status, status.lowercased() == "closed" else {
+            mainTitleLabel.textColor = blackColor
+            mainSubtitleLabel.textColor = blackColor
+            return
+        }
         mainTitleLabel.textColor = closedBlackColor
         mainSubtitleLabel.textColor = closedBlackColor
     }

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemContentModelMapper.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemContentModelMapper.swift
@@ -17,6 +17,7 @@ class MLBusinessCoverCarouselItemContentModelMapper: MLBusinessCoverCarouselItem
                                               leftImageAccessory: model.leftImageAccessory,
                                               leftImageStatus: model.leftImageStatus,
                                               mainTitle: model.mainTitle,
+                                              mainTitleStatus: model.mainTitleStatus,
                                               mainSubtitle: model.mainSubtitle,
                                               mainDescription: model.mainDescription,
                                               mainSecondaryDescription: model.mainSecondaryDescription,

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemModel.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Card/MLBusinessCoverCarouselItemModel.swift
@@ -45,6 +45,7 @@ public struct MLBusinessCoverCarouselItemContentModel: Codable {
     public let leftImageAccessory: String?
     public let leftImageStatus: String?
     public let mainTitle: String
+    public let mainTitleStatus: String?
     public let mainSubtitle: String?
     public let mainDescription: [MLBusinessRowMainDescription]?
     public let mainSecondaryDescription: [MLBusinessMultipleDescriptionModel]?
@@ -61,6 +62,7 @@ public struct MLBusinessCoverCarouselItemContentModel: Codable {
                 leftImageAccessory: String?,
                 leftImageStatus: String? = nil,
                 mainTitle: String,
+                mainTitleStatus: String? = nil,
                 mainSubtitle: String?,
                 mainDescription: [MLBusinessRowMainDescription]?,
                 mainSecondaryDescription: [MLBusinessMultipleDescriptionModel]?,
@@ -76,6 +78,7 @@ public struct MLBusinessCoverCarouselItemContentModel: Codable {
         self.leftImageAccessory = leftImageAccessory
         self.leftImageStatus = leftImageStatus
         self.mainTitle = mainTitle
+        self.mainTitleStatus = mainTitleStatus
         self.mainSubtitle = mainSubtitle
         self.mainDescription = mainDescription
         self.mainSecondaryDescription = mainSecondaryDescription

--- a/Source/Components/Touchpoints/Types/MultipleRow/MLBusinessTouchpointsMultipleRowModel.swift
+++ b/Source/Components/Touchpoints/Types/MultipleRow/MLBusinessTouchpointsMultipleRowModel.swift
@@ -50,6 +50,7 @@ public class MLBusinessMultipleRowItemModel: NSObject, Codable {
     private let leftImageAccessory: String?
     private let leftImageStatus: String?
     private let mainTitle: String
+    private let mainTitleStatus: String?
     private let mainSubtitle: String?
     private let mainDescription: [MLBusinessRowMainDescription]?
     private let mainSecondaryDescription: [MLBusinessMultipleDescriptionModel]?
@@ -63,11 +64,12 @@ public class MLBusinessMultipleRowItemModel: NSObject, Codable {
     private let link: String?
     private let tracking: MLBusinessItemModelTracking?
     
-    public init(leftImage: String?, leftImageAccessory: String?, leftImageStatus: String? = nil, mainTitle: String, mainSubtitle: String?, mainDescription: [MLBusinessRowMainDescription]?, mainSecondaryDescription: [MLBusinessMultipleDescriptionModel]? = nil, statusDescription: [MLBusinessMultipleDescriptionModel]? = nil, rightPrimaryLabel: String?, rightSecondaryLabel: String?, rightMiddleLabel: String?, rightTopLabel: String?, rightLabelStatus: String?, rightBottomInfo: MLBusinessRowRightBottomInfo?, link: String?, tracking: MLBusinessItemModelTracking?) {
+    public init(leftImage: String?, leftImageAccessory: String?, leftImageStatus: String? = nil, mainTitle: String, mainTitleStatus: String? = nil, mainSubtitle: String?, mainDescription: [MLBusinessRowMainDescription]?, mainSecondaryDescription: [MLBusinessMultipleDescriptionModel]? = nil, statusDescription: [MLBusinessMultipleDescriptionModel]? = nil, rightPrimaryLabel: String?, rightSecondaryLabel: String?, rightMiddleLabel: String?, rightTopLabel: String?, rightLabelStatus: String?, rightBottomInfo: MLBusinessRowRightBottomInfo?, link: String?, tracking: MLBusinessItemModelTracking?) {
         self.leftImage = leftImage
         self.leftImageAccessory = leftImageAccessory
         self.leftImageStatus = leftImageStatus
         self.mainTitle = mainTitle
+        self.mainTitleStatus = mainTitleStatus
         self.mainSubtitle = mainSubtitle
         self.mainDescription = mainDescription
         self.mainSecondaryDescription = mainSecondaryDescription
@@ -98,6 +100,10 @@ extension MLBusinessMultipleRowItemModel: MLBusinessRowData {
     
     public func getMainTitle() -> String {
         return mainTitle
+    }
+    
+    public func getMainTitleStatus() -> String? {
+        return mainTitleStatus
     }
     
     public func getMainSubtitle() -> String? {


### PR DESCRIPTION
## Descripción

- Se permite grisar el título y el subtítulo de la HybridRow desde BE.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

![Captura de pantalla 2021-07-06 a las 20 38 00](https://user-images.githubusercontent.com/49250268/124679561-06c80100-de9b-11eb-9015-8db93e8e15c0.png)

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [x] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [x] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
