### PR TITLE
Feature/cover carousel touchpoint fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Sin publicar
+- Fix en `setAdditionalEdgeInsets(with:)` para el Cover Carousel
+
 # v1.30.0
 🚀 1.30.0 🚀
 - Static frameworks

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Carousel/MLBusinessCoverCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Carousel/MLBusinessCoverCarouselView.swift
@@ -56,6 +56,8 @@ public class MLBusinessCoverCarouselView: UIView {
         }
     }
     
+    var cardWidth: CGFloat = UIScreen.main.bounds.width - 32
+    
     public weak var delegate: MLBusinessCoverCarouselViewDelegate?
     
     public var shouldHighlightItems = true
@@ -159,7 +161,7 @@ extension MLBusinessCoverCarouselView: UICollectionViewDataSource {
 
 extension MLBusinessCoverCarouselView: UICollectionViewDelegateFlowLayout {
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: UIScreen.main.bounds.width - 32, height: getMaxItemHeight(for: model))
+        return CGSize(width: cardWidth, height: getMaxItemHeight(for: model))
     }
 }
 

--- a/Source/Components/Touchpoints/Types/CoverCarousel/Touchpoint/MLBusinessTouchpointsCoverCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/CoverCarousel/Touchpoint/MLBusinessTouchpointsCoverCarouselView.swift
@@ -46,18 +46,18 @@ class MLBusinessTouchpointsCoverCarouselView: MLBusinessTouchpointsBaseView {
     }
     
     override func setAdditionalEdgeInsets(with insets: [String : Any]?) {
-        guard var additionalInsets = insets else { return }
-        let insets = UIEdgeInsets(top: 0,
+        guard let additionalInsets = insets else { return }
+        let insets = UIEdgeInsets(top: CGFloat(truncating: additionalInsets["top"] as? NSNumber ?? 0),
                                   left: CGFloat(truncating: additionalInsets["left"] as? NSNumber ?? 0),
-                                  bottom: 0,
-                                  right: CGFloat(truncating: additionalInsets["right"] as? NSNumber ?? 0) + 12.0)
+                                  bottom: CGFloat(truncating: additionalInsets["bottom"] as? NSNumber ?? 0),
+                                  right: CGFloat(truncating: additionalInsets["right"] as? NSNumber ?? 0))
         
-        additionalInsets["left"] = 0.0
-        additionalInsets["right"] = 0.0
-        
-        super.setAdditionalEdgeInsets(with: additionalInsets)
+        topConstraint?.constant = insets.top
+        bottomConstraint?.constant = -insets.bottom
 
-        collectionView.contentInset = insets
+        collectionView.cardWidth = UIScreen.main.bounds.width - insets.left - insets.right
+        collectionView.contentInset.left = insets.left
+        collectionView.contentInset.right = insets.right
     }
     
     override func getVisibleItems() -> [Trackable]? {


### PR DESCRIPTION
## Nota

- Cierro [el viejo PR de Gas](https://github.com/mercadolibre/mlbusiness-components-ios/pull/114) y abro este otro con los mismos cambios ya que no me permite pushear sobre su branch y necesito actualizar el **CHANGELOG**. 

## Descripción

- Este **PR** arregla la forma en la que se comporta el método `setAdditionalEdgeInsets(with:)` en el _touchpoint_ del `CoverCarousel`. De esta manera, queda el touchpoint configurable y listo para ser incluido en la home.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Screenshots - Gifs

![carrousel_de_marcas_destacadas](https://user-images.githubusercontent.com/49250268/124813822-ae950b80-df3b-11eb-8fca-20c551b57092.gif)

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [x] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [x] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
