### PR TITLE
Add optional icon color support on item description data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Sin Publicar
+- Added optional icon color support on item description data
+
 # v1.32.0
 🚀 1.32.0 🚀
 - Added `main_label_top` attribute on Hybrid Row

--- a/Source/Components/Item Description/MLBusinessItemDescriptionData.swift
+++ b/Source/Components/Item Description/MLBusinessItemDescriptionData.swift
@@ -11,4 +11,11 @@ import UIKit
     @objc func getTitle() -> String
     @objc func getIconImageURL() -> String
     @objc func getIconHexaColor() -> String
+    @objc optional func getOptionalIconHexaColor() -> String?
+}
+
+extension MLBusinessItemDescriptionData {
+    func getOptionalIconHexaColor() -> String? {
+        return nil
+    }
 }


### PR DESCRIPTION
## Descripción

Se agrega el método `getOptionalIconHexaColor()` a `MLBusinessItemDescriptionData` para soporte de DTOs con `primary_color == nil` en los que se requiera renderizar la imagen con sus colores originales.

Se decidió adjuntar este método en lugar de modificar el ya existente `getIconHexaColor()` para evitar romper la firma del protocolo y generar incompatibilidades entre módulos.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Issues

- [MER-6561](https://mercadolibre.atlassian.net/browse/MER-6561)

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [x] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [x] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
