### PR TITLE
Fix item optional color support

### DIFF
--- a/Source/Components/Item Description/MLBusinessItemDescriptionData.swift
+++ b/Source/Components/Item Description/MLBusinessItemDescriptionData.swift
@@ -11,5 +11,5 @@ import UIKit
     @objc func getTitle() -> String
     @objc func getIconImageURL() -> String
     @objc func getIconHexaColor() -> String
-    func getOptionalIconHexaColor() -> String?
+    @objc optional func getOptionalIconHexaColor() -> String?
 }

--- a/Source/Components/Item Description/MLBusinessItemDescriptionData.swift
+++ b/Source/Components/Item Description/MLBusinessItemDescriptionData.swift
@@ -11,11 +11,5 @@ import UIKit
     @objc func getTitle() -> String
     @objc func getIconImageURL() -> String
     @objc func getIconHexaColor() -> String
-    @objc optional func getOptionalIconHexaColor() -> String?
-}
-
-extension MLBusinessItemDescriptionData {
-    func getOptionalIconHexaColor() -> String? {
-        return nil
-    }
+    func getOptionalIconHexaColor() -> String?
 }


### PR DESCRIPTION
## Descripción

Se quita la implementación default de `getOptionalIconHexaColor()` porque trajo problemas en la implementación propia de las clases que cumplen el protocolo.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Issues

- [MER-6561](https://mercadolibre.atlassian.net/browse/MER-6561)

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [x] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [x] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
