### PR TITLE
[MER-6561] Arreglar muestra de imágenes en componente de beneficios de homes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-# Sin Publicar
+# Sin publicar
+- Use optional icon color on benefits item
+
+# v1.33.1
+🚀 1.33.1 🚀
+- Removed default initializer for optional icon color support on item description data
+
+# v1.33.0
+🚀 1.33.0 🚀
 - Added optional icon color support on item description data
 
 # v1.32.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Sin publicar
-- Use optional icon color on benefits item
+- Allow optional icon color usage on benefits items
 
 # v1.33.1
 🚀 1.33.1 🚀

--- a/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
+++ b/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
@@ -80,14 +80,23 @@ private extension MLBusinessItemDescriptionView {
     }
     
     private func setupImageView(image: UIImage) {
-        if let imageColor = self.viewData?.getOptionalIconHexaColor?()?.hexaToUIColor() {
-            self.iconImageView?.backgroundColor = imageColor
+        if let backgroundColor = getIconBackgroundColor() {
+            self.iconImageView?.backgroundColor = backgroundColor
             self.iconImageView?.image = image.ml_tintedImage(with: .white)
         } else {
             self.iconImageView?.image = image
         }
     }
     
+    private func getIconBackgroundColor() -> UIColor? {
+        if let viewData = self.viewData,
+           viewData.responds(to: Selector("getOptionalIconHexaColor")) {
+            return viewData.getOptionalIconHexaColor?()?.hexaToUIColor()
+        } else {
+            return self.viewData?.getIconHexaColor().hexaToUIColor()
+        }
+    }
+        
     // MARK: Constraints.
     func makeConstraints(_ titleLabel: UILabel, _ iconImageView: UIImageView) {
         NSLayoutConstraint.activate([

--- a/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
+++ b/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
@@ -80,7 +80,7 @@ private extension MLBusinessItemDescriptionView {
     }
     
     private func setupImageView(image: UIImage) {
-        if let imageColor = self.viewData?.getIconHexaColor().hexaToUIColor() {
+        if let imageColor = self.viewData?.getOptionalIconHexaColor?()?.hexaToUIColor() {
             self.iconImageView?.backgroundColor = imageColor
             self.iconImageView?.image = image.ml_tintedImage(with: .white)
         } else {


### PR DESCRIPTION
## Descripción

El método [`getIconHexaColor()`](https://github.com/mercadolibre/fury_homes-ios/blob/17f5bb5d4ffe4ba2881e7da25123d2a5c372629e/LibraryComponents/Classes/v2/Feed/Model/MLHomeIconDescription.swift#L48) de `MLHomeIconDescription` devuelve siempre un color hexadecimal (cuando el modelo tiene `primaryColor == nil`, defaultea a `"FFFFFF"`).

Para utilizar iconos con colores propios, necesitamos diferenciar modelos con `primaryColor == nil` y así poder ejecutar [esta línea](https://github.com/mercadolibre/mlbusiness-components-ios/blob/ae88b0e1940de2bf74278687a52ca01d34e32240/Source/Components/Item%20Description/MLBusinessItemDescriptionView.swift#L87) que muestra la imagen correctamente, sin alterarla.

Se propone utilizar [`getOptionalIconHexaColor()`](https://github.com/mercadolibre/fury_homes-ios/blob/17f5bb5d4ffe4ba2881e7da25123d2a5c372629e/LibraryComponents/Classes/v2/Feed/Model/MLHomeIconDescription.swift#L52) cuando está disponible, que devuelve `nil` si no hay `primaryColor`. En caso de no estar implementado este método, se llama al antiguo `getIconHexaColor()` manteniendo total compatibilidad.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Issues

[MER-6561](https://mercadolibre.atlassian.net/browse/MER-6561)

## Screenshots - Gifs

Caso 1: `getOptionalIconHexaColor()` sin implementar (se llama `getIconHexaColor()`) con iconos clásicos
https://user-images.githubusercontent.com/6852497/142454367-ff8bbc93-bbe0-4ae2-b234-f3f5d2ffdd33.mp4

Caso 2: con `getOptionalIconHexaColor()` implementado, probamos ambos tipos de iconos
https://user-images.githubusercontent.com/6852497/142454965-e6c998d9-aa0f-471b-bd6b-9b193d130fcf.mp4



### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [x] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [x] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
