### PR TITLE
Arruma a forma que VoiceOver le os itens no carrossel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Sin Publicar
+- Fix accessibility in carousel touchpoints
+
 # v1.34.1
 🚀 1.34.1 🚀
 - Allow optional icon color usage on benefits items

--- a/Source/Components/Touchpoints/Types/Carousel/MLBusinessCarouselContainerView .swift
+++ b/Source/Components/Touchpoints/Types/Carousel/MLBusinessCarouselContainerView .swift
@@ -51,6 +51,7 @@ public class MLBusinessCarouselContainerView: UIView {
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.showsVerticalScrollIndicator = false
         collectionView.isPagingEnabled = false
+        collectionView.isAccessibilityElement = false
         return collectionView
     }()
     
@@ -71,6 +72,7 @@ public class MLBusinessCarouselContainerView: UIView {
         setup()
         setupDataHandler()
         setupConstraints()
+        isAccessibilityElement = false
     }
 
     private func setup() {

--- a/Source/Components/Touchpoints/Types/Carousel/MLBusinessTouchpointsCarouselContainerItemView.swift
+++ b/Source/Components/Touchpoints/Types/Carousel/MLBusinessTouchpointsCarouselContainerItemView.swift
@@ -252,6 +252,17 @@ class MLBusinessTouchpointsCarouselContainerItemView: UIView {
         }
 
         applyFormats(to: item)
+        
+        guard
+            let topLabel = item.topLabel,
+            let mainLabel = item.mainLabel,
+            let rightLabel = item.rightLabel,
+            let itemTitle = item.title,
+            let subTitle = item.subtitle else {
+                return
+            }
+        
+        accessibilityLabel = "\(topLabel) \(mainLabel) \(rightLabel) \(itemTitle) \(subTitle)"
     }
 
     public func clear() {

--- a/Source/Components/Touchpoints/Types/Carousel/MLBusinessTouchpointsCarouselContainerItemView.swift
+++ b/Source/Components/Touchpoints/Types/Carousel/MLBusinessTouchpointsCarouselContainerItemView.swift
@@ -253,16 +253,7 @@ class MLBusinessTouchpointsCarouselContainerItemView: UIView {
 
         applyFormats(to: item)
         
-        guard
-            let topLabel = item.topLabel,
-            let mainLabel = item.mainLabel,
-            let rightLabel = item.rightLabel,
-            let itemTitle = item.title,
-            let subTitle = item.subtitle else {
-                return
-            }
-        
-        accessibilityLabel = "\(topLabel) \(mainLabel) \(rightLabel) \(itemTitle) \(subTitle)"
+        accessibilityLabel = "\(item.topLabel ?? "") \(item.mainLabel ?? "") \(item.rightLabel ?? "") \(item.title ?? "") \(item.subtitle ?? "")"
     }
 
     public func clear() {

--- a/Source/Components/Touchpoints/Types/Carousel/MLBusinessTouchpointsCarouselContainerViewCell.swift
+++ b/Source/Components/Touchpoints/Types/Carousel/MLBusinessTouchpointsCarouselContainerViewCell.swift
@@ -48,6 +48,7 @@ class MLBusinessTouchpointsCarouselContainerViewCell: UICollectionViewCell {
             backgroundColor = currentBackgroundColor ?? .white
         }
         itemView.update(with: content)
+        accessibilityLabel = itemView.accessibilityLabel
     }
     
     func update(height: CGFloat) {

--- a/Source/Components/Touchpoints/Types/Carousel/MLBusinessTouchpointsCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/Carousel/MLBusinessTouchpointsCarouselView.swift
@@ -27,6 +27,7 @@ class MLBusinessTouchpointsCarouselView: MLBusinessTouchpointsBaseView {
         super.init(configuration: configuration)
         setup()
         setupConstraints()
+        isAccessibilityElement = false
     }
 
     private func setup() {

--- a/Source/Components/Touchpoints/Types/Carousel/MLBusinessTouchpointsCollectionViewDataHandler.swift
+++ b/Source/Components/Touchpoints/Types/Carousel/MLBusinessTouchpointsCollectionViewDataHandler.swift
@@ -87,6 +87,8 @@ extension MLBusinessTouchpointsCollectionViewDataHandler: UICollectionViewDataSo
         let item = items[indexPath.row]
         cell.imageProvider = imageProvider
         cell.update(with: item)
+        cell.isAccessibilityElement = true
+        cell.shouldGroupAccessibilityChildren = true
         
         if let height = collectionViewHeightConstraint {
             cell.update(height: height.constant)


### PR DESCRIPTION
## Descripción

**Probletica:**
O carrossel de "Descobrir Locais" na Home do MercadoPago estava sendo ignorado pelo Voice Over

**Solução:**
O Voice Over sempre tenta ler o objetivo mais acima na hierarquia, porem como nossa célula está níveis hierárquicos mais a baixo, foi desativado nas camadas superiores a acessibilidade da view, deixando apenas as células visíveis.

Essa PR tem dependencia com a PR
https://github.com/mercadolibre/fury_instore-home-sections-ios/pull/87

## Tipo:

- [x] Bugfix
- [ ] Feature or Improvement

## Issues.


## Screenshots - Gifs
**Antes:**
<img width="600" alt="Captura de Tela 2022-03-02 às 15 57 25" src="https://user-images.githubusercontent.com/94873622/156443077-265e72a3-147a-44e1-819d-d7bf2813c601.png">

![gifAcessibilidadeAntes](https://user-images.githubusercontent.com/94873622/156443784-19658892-61fb-49ac-89c4-c47117fc7523.gif)


**Depois:** 
<img width="600" alt="Captura de Tela 2022-03-02 às 15 30 11" src="https://user-images.githubusercontent.com/94873622/156443160-ab84535e-b6cf-4314-92e7-b21bda6aef56.png">

![gifAcessibilidadeDepois](https://user-images.githubusercontent.com/94873622/156444456-1e9d5a36-8051-4daf-b4c5-e2a9050713bc.gif)


### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
