### PR TITLE
Fix Touchpoint Cell Reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# sin publicar
+- Fix in how FlexCoverCarousel Cells were reusing data.
+
 # v1.41.0
 🚀 1.41.0 🚀
 - Added support for multiple logos in Touchpoint FlexCoverCarousel.

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -287,5 +287,9 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
     public func prepareForReuse() {
         coverImageView.image = nil
         logoStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        mainSubtitleLabel.text = nil
+        mainDescriptionLabel.text = nil
+        mainTitleTopLabel.text = nil
+        pillLabel.text = nil
     }
 }


### PR DESCRIPTION
## Descripción
Metodo prepareForReuse no estaba implementado correctamente, se estaban pisando los wordings que llegaban de be para los casos donde un texto venia en nil.

## Tipo:

- [x] Bugfix
- [ ] Feature or Improvement

## Screenshots - Gifs

![Simulator Screen Recording - iPhone 13 Pro Max - 2022-07-06 at 14 13 30](https://user-images.githubusercontent.com/97110592/177606673-75aa695e-4576-4710-9886-df63b91ab751.gif)

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
