### PR TITLE
Change number of lines in Business Item Description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # sin publicar
+- Changed MLBusinessItemDescriptionView title number of lines to 3
+
+# v1.42.0
+🚀 1.42.0 🚀
 - Fix in how FlexCoverCarousel Cells were reusing data.
 - Added Skeleton View for Touchpoint FlexCoverCarousel.
 

--- a/MLBusinessComponents.podspec
+++ b/MLBusinessComponents.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MLBusinessComponents"
-  s.version          = "1.41.0"
+  s.version          = "1.42.0"
   s.summary          = "MLBusinessComponents for iOS"
   s.homepage         = "https://www.mercadolibre.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
+++ b/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
@@ -12,7 +12,7 @@ public final class MLBusinessItemDescriptionView: UIView {
     private var viewData: MLBusinessItemDescriptionData?
     
     private let viewHeight: CGFloat = 36
-    private let iconImageSize: CGFloat = 36
+    private let iconImageSize: CGFloat = 42
     private let titleNumberOfLines: Int = 3
     
     private weak var iconImageView: UIImageView?

--- a/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
+++ b/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
@@ -39,7 +39,7 @@ public final class MLBusinessItemDescriptionView: UIView {
 private extension MLBusinessItemDescriptionView {
     
     private func update() {
-        titleLabel?.text = viewData?.getTitle()
+        titleLabel?.text = "45% OFF en envíos de millones de productos de menos de $ 5.500"
         if let url = viewData?.getIconImageURL() {
             iconImageView?.setRemoteImage(imageUrl: url, success: { [weak self] loadedImage in
                 self?.setupImageView(image: loadedImage)

--- a/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
+++ b/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
@@ -13,7 +13,7 @@ public final class MLBusinessItemDescriptionView: UIView {
     
     private let viewHeight: CGFloat = 36
     private let iconImageSize: CGFloat = 36
-    private let titleNumberOfLines: Int = 2
+    private let titleNumberOfLines: Int = 3
     
     private weak var iconImageView: UIImageView?
     private weak var titleLabel: UILabel?

--- a/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
+++ b/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
@@ -12,7 +12,7 @@ public final class MLBusinessItemDescriptionView: UIView {
     private var viewData: MLBusinessItemDescriptionData?
     
     private let viewHeight: CGFloat = 36
-    private let iconImageSize: CGFloat = 42
+    private let iconImageSize: CGFloat = 36
     private let titleNumberOfLines: Int = 3
     
     private weak var iconImageView: UIImageView?

--- a/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
+++ b/Source/Components/Item Description/MLBusinessItemDescriptionView.swift
@@ -39,7 +39,7 @@ public final class MLBusinessItemDescriptionView: UIView {
 private extension MLBusinessItemDescriptionView {
     
     private func update() {
-        titleLabel?.text = "45% OFF en envíos de millones de productos de menos de $ 5.500"
+        titleLabel?.text = viewData?.getTitle()
         if let url = viewData?.getIconImageURL() {
             iconImageView?.setRemoteImage(imageUrl: url, success: { [weak self] loadedImage in
                 self?.setupImageView(image: loadedImage)


### PR DESCRIPTION
## Descripción

Se permite que el componente MLBusinessItemDescriptionView pueda tener textos de 3 lineas. Adaptandose a los beneficios que puede llegar a mostrar Loyalty en su componente

## Antes 
![Captura de Pantalla 2022-08-10 a la(s) 17 08 34](https://user-images.githubusercontent.com/34245163/184011816-3ebcf858-49cd-4b38-9814-5ef354b8d5db.png)

## Después con benefit de 3 líneas
![Captura de Pantalla 2022-08-10 a la(s) 17 07 09](https://user-images.githubusercontent.com/34245163/184011819-ff4f31cd-10b7-4e7f-813b-16a76e060e41.png)

## Tipo:

- [ ] Bugfix
- [X] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [X] Probé la biblioteca en Mercado Pago (Obligatorio)
- [X] Probé la biblioteca en Mercado Libre (Obligatorio)
- [X] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
