### PR TITLE
Fix para textos en nil - FlexCoverCarousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# sin publicar
+- Fix FlexCoverCarousel cards when receiving nil in text parameters.
+
 # v1.42.0
 🚀 1.42.0 🚀
 - Fix in how FlexCoverCarousel Cells were reusing data.

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemModel.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemModel.swift
@@ -43,8 +43,8 @@ extension MLBusinessFlexCoverCarouselItemModel: Trackable {
 }
 
 public struct FlexCoverCarouselItemText: Codable {
-    public let text: String
-    public let textColor: String
+    public let text: String?
+    public let textColor: String?
 }
 
 public struct FlexCoverCarouselLogo: Codable {


### PR DESCRIPTION
## Descripción
Se corrige bug visual que hacia que la card del FlexCoverCarousel se vea en blanco cuando un objeto de texto venia desde como nil. 

ejemplo: 
`"title": {
                                },
                                "subtitle": {
                                },`

## Tipo:

- [x] Bugfix
- [ ] Feature or Improvement



## Screenshots - Gifs
| Antes | Despues |
|--|------|
|![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 17 34 25 copia](https://user-images.githubusercontent.com/97110592/184985017-258d06b0-187d-4d81-a37e-e87f8ebff2c1.jpg)| ![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 18 06 21](https://user-images.githubusercontent.com/97110592/184985219-bd415d68-b038-430d-98bf-cc4cd955f217.png)|

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
