### PR TITLE
Fix Label Text Color - FlexCoverCarousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # sin publicar
 - Changed MLBusinessItemDescriptionView title number of lines to 3
+- Fix for cases when we don't have the labels' color values from be
 
 # v1.42.0
 🚀 1.42.0 🚀

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -9,6 +9,7 @@ import UIKit
 import MLUI
 
 public class MLBusinessFlexCoverCarouselItemView: UIView {
+    fileprivate enum Layout {}
     static let coverHeight: CGFloat = 104
     static let containerHeight: CGFloat = 56
     var imageProvider: MLBusinessImageProvider
@@ -126,8 +127,8 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
     }
     
     private func createPillView(with pill: FlexCoverCarouselPill?) {
-        let backgroundColor = pill?.backgroundColor ?? "#009EE3"
-        let borderColor = pill?.borderColor ?? "#009EE3"
+        let backgroundColor = pill?.backgroundColor ?? Layout.Color.defaultPillColor
+        let borderColor = pill?.borderColor ?? Layout.Color.defaultPillColor
         let borderUiColor = borderColor.hexaToUIColor()
         
         bottomPillView.backgroundColor =  backgroundColor.hexaToUIColor()
@@ -173,13 +174,14 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
     }
     
     private func createPillSecttion(with item: MLBusinessFlexCoverCarouselItemModel) {
-        if item.pill?.text != nil && item.pill?.text != "" {
-            createPillView(with: item.pill)
-            createPillLabel(with: item.pill)
-        } else {
+        guard let textPill = item.pill?.text, !textPill.isEmpty else {
             bottomPillView.isHidden = true
             pillLabel.isHidden = true
+            return
         }
+        
+        createPillView(with: item.pill)
+        createPillLabel(with: item.pill)
     }
     
     private func createLogoSection(with item: MLBusinessFlexCoverCarouselItemModel) {
@@ -305,5 +307,11 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         mainDescriptionLabel.text = nil
         mainTitleTopLabel.text = nil
         pillLabel.text = nil
+    }
+}
+
+extension MLBusinessFlexCoverCarouselItemView.Layout {
+    enum Color {
+        static var defaultPillColor = "#009EE3"
     }
 }

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -103,33 +103,36 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
     private func createMainTitleTop(with text: String?, color: String?) {
         guard let mainTitleTopText = text else { return }
         mainTitleTopLabel.text = mainTitleTopText
-        mainTitleTopLabel.textColor = color?.hexaToUIColor() ?? MLStyleSheetManager.styleSheet.blackColor
+        mainTitleTopLabel.textColor = getLabelUIColor(color)
     }
     
     private func createMainSubtitle(with text: String?, color: String?) {
         guard let mainSubtitleText = text else { return }
         mainSubtitleLabel.text = mainSubtitleText
-        mainSubtitleLabel.textColor = color?.hexaToUIColor() ?? MLStyleSheetManager.styleSheet.blackColor
+        mainSubtitleLabel.textColor = getLabelUIColor(color)
     }
     
     private func createMainDescription(with text: String?, color: String?) {
         guard let mainDescription = text else { return }
         mainDescriptionLabel.text = mainDescription
-        mainDescriptionLabel.textColor = color?.hexaToUIColor() ?? MLStyleSheetManager.styleSheet.blackColor
+        mainDescriptionLabel.textColor = getLabelUIColor(color)
     }
     
     private func createPillLabel(with pill: FlexCoverCarouselPill?) {
-        guard let text = pill?.text, let textColor = pill?.textColor else { return }
-        pillLabel.text = pill?.text
-        pillLabel.textColor = textColor.hexaToUIColor() ?? MLStyleSheetManager.styleSheet.whiteColor
+        guard let pillText = pill?.text else { return }
+        pillLabel.text = pillText
+        pillLabel.textColor = getLabelUIColor(pill?.textColor)
+        pillLabel.isHidden = false
     }
     
     private func createPillView(with pill: FlexCoverCarouselPill?) {
-        guard let backgroundColor = pill?.backgroundColor, let borderColor = pill?.borderColor else { return }
-        let borderUiColor = borderColor.hexaToUIColor() ?? MLStyleSheetManager.styleSheet.whiteColor
+        let backgroundColor = pill?.backgroundColor ?? "#009EE3"
+        let borderColor = pill?.borderColor ?? "#009EE3"
+        let borderUiColor = borderColor.hexaToUIColor()
         
-        bottomPillView.backgroundColor =  backgroundColor.hexaToUIColor() ?? MLStyleSheetManager.styleSheet.whiteColor
+        bottomPillView.backgroundColor =  backgroundColor.hexaToUIColor()
         bottomPillView.layer.borderColor = borderUiColor.cgColor
+        bottomPillView.isHidden = false
     }
     
     private func createGradientView() {
@@ -163,20 +166,31 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         }
     }
     
-    
     private func createMainSection(with item: MLBusinessFlexCoverCarouselItemModel) {
         createMainTitleTop(with: item.title?.text, color: item.title?.textColor)
-        createMainSubtitle(with: item.subtitle?.text, color: item.title?.textColor)
+        createMainSubtitle(with: item.subtitle?.text, color: item.subtitle?.textColor)
         createMainDescription(with: item.mainDescription?.text, color: item.mainDescription?.textColor)
     }
     
     private func createPillSecttion(with item: MLBusinessFlexCoverCarouselItemModel) {
-        createPillView(with: item.pill)
-        createPillLabel(with: item.pill)
+        if item.pill?.text != nil && item.pill?.text != "" {
+            createPillView(with: item.pill)
+            createPillLabel(with: item.pill)
+        } else {
+            bottomPillView.isHidden = true
+            pillLabel.isHidden = true
+        }
     }
     
     private func createLogoSection(with item: MLBusinessFlexCoverCarouselItemModel) {
         createLogoView(logos: item.logos ?? [])
+    }
+    
+    private func getLabelUIColor(_ textColor: String?) -> UIColor {
+        if let color = textColor, !color.isEmpty{
+            return color.hexaToUIColor()
+        }
+        return MLStyleSheetManager.styleSheet.whiteColor
     }
         
     public init(with imageProvider: MLBusinessImageProvider? = nil) {


### PR DESCRIPTION
## Descripción
Fix para casos border en donde desde be podríamos no tener los valores de text_color para los labels del FlexCoverCarousel. También se toma en cuenta el caso en donde no tenemos text para la pill, en ese caso ahora ocultamos esa vista.


## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement


## Screenshots - Gifs

|Antes| Después|
|-----|----| 
|![Simulator Screen Recording - iPhone 13 - 2022-08-17 at 12 16 44](https://user-images.githubusercontent.com/97110592/185182110-f81b979f-366f-4f44-a3c8-413a7c92d20e.gif)|![Simulator Screen Recording - iPhone 13 - 2022-08-17 at 11 42 51](https://user-images.githubusercontent.com/97110592/185182196-cdd648e0-34c8-46c1-832d-67064fcfdc71.gif)|



### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
