### PR TITLE
[Flex Cover Carousel ] - Fix tracking Print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Fixed
+- Fix issue in tracking print for component FlexCoverCarousel
+
 # v1.43.1
 🚀 1.43.1 🚀
 - Changed MLBusinessItemDescriptionView title number of lines to 3

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Carousel/MLBusinessFlexCoverCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Carousel/MLBusinessFlexCoverCarouselView.swift
@@ -140,7 +140,7 @@ extension MLBusinessFlexCoverCarouselView: UICollectionViewDelegateFlowLayout {
 extension MLBusinessFlexCoverCarouselView: CarouselCollectionViewHelperDelegate {
     
     func carouselDelegateDidScrollToItem(_ carouselDelegate: CarouselCollectionViewHelper) {
-        delegate?.coverCarouselView(self, didFinishScrolling: items)
+        delegate?.coverCarouselView(self, didFinishScrolling: visibleItems)
     }
     
     func carouselDelegate(_ carouselDelegate: CarouselCollectionViewHelper, didSelectItemAt indexPath: IndexPath) {


### PR DESCRIPTION
## Descripción

Se arregla problema en tracking de prints que hacia que se trackeen todos los items del componente en vez de solo los visibles.

## Tipo:

- [x] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1


### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
