### PR TITLE
[CHANGE] Se modifica la posición de elementos de FlexCoverCarousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
+## [Unreleased]
+
+### Changed
+- Updated FlexCoverCarousel padding values.
+
 # v1.44.0
 🚀 1.44.0 🚀
 ### Fixed
 - Fix issue in tracking print for component FlexCoverCarousel
 
-### Modified
+### Changed
 - Gradient height changes on FlexCoverCarousel
 - Title position dynamic on FlexCoverCarousel
 - Paddings changes

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -170,13 +170,7 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
     private func createLogoView(logos: [FlexCoverCarouselLogo]) {
         for logo in logos {
             let logoView = MLBusinessFlexCoverCarouselLogoViewFactory.provide(logo: logo)
-            let constant = (logo.style?.height ?? 0) + 48
             logoStackView.addArrangedSubview(logoView)
-            
-            NSLayoutConstraint.activate([
-                logoStackView.heightAnchor.constraint(equalTo: logoView.heightAnchor),
-                logoStackView.bottomAnchor.constraint(equalTo: mainDescriptionLabel.topAnchor, constant: -CGFloat(constant))
-            ])
         }
     }
     
@@ -247,7 +241,6 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
     }
     
     private func setupView() {
-        
         translatesAutoresizingMaskIntoConstraints = false
         layer.masksToBounds = true
         addSubview(coverImageView)
@@ -259,12 +252,10 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         bottomPillView.addSubview(pillLabel)
         addSubview(headerContainer)
         addSubview(mainDescriptionLabel)
-        addSubview(containerView)
-        containerView.addSubview(logoStackView)
+        addSubview(logoStackView)
     }
     
     private func setupConstraints() {
-        
         NSLayoutConstraint.activate([
             alphaOverlayView.topAnchor.constraint(equalTo: topAnchor),
             alphaOverlayView.bottomAnchor.constraint(equalTo: bottomAnchor),
@@ -288,8 +279,8 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
             mainCardContainerView.heightAnchor.constraint(equalToConstant:MLBusinessFlexCoverCarouselItemView.containerHeight),
             
             headerContainer.bottomAnchor.constraint(equalTo: mainDescriptionLabel.topAnchor, constant: -4),
-            headerContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            headerContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            headerContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            headerContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
             
             mainDescriptionLabel.leadingAnchor.constraint(equalTo: headerContainer.leadingAnchor),
             mainDescriptionLabel.trailingAnchor.constraint(equalTo: headerContainer.trailingAnchor),
@@ -304,11 +295,9 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
             pillLabel.leadingAnchor.constraint(equalTo: bottomPillView.leadingAnchor, constant: 6),
             pillLabel.trailingAnchor.constraint(equalTo: bottomPillView.trailingAnchor, constant: -6),
             
-            logoStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            logoStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
-            
-            containerView.leadingAnchor.constraint(equalTo: headerContainer.leadingAnchor),
-            containerView.trailingAnchor.constraint(equalTo: headerContainer.trailingAnchor),
+            logoStackView.leadingAnchor.constraint(equalTo: headerContainer.leadingAnchor),
+            logoStackView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+            logoStackView.bottomAnchor.constraint(lessThanOrEqualTo: mainDescriptionLabel.topAnchor, constant: -48)
         ])
     }
     

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -39,13 +39,6 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         return stackView
     }()
     
-    private lazy var containerView: UIView = {
-        let view = UIView(frame: .zero)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.clipsToBounds = false
-        return view
-    }()
-    
     private lazy var coverImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## Descripción

- Se mueven los logos a la parte superior
- Se modifica el espacio horizontal para los elementos dentro de la card.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Screenshots - Gifs

| iPhone SE | iPhone 13 Pro Max |
|-----------|-------------------|
|  <img width="350" alt="se" src="https://user-images.githubusercontent.com/45976466/200909779-811b8c8b-0957-4689-97a0-329622a06e80.png">  |  <img width="400" alt="max" src="https://user-images.githubusercontent.com/45976466/200912872-7c59690e-f07d-4735-bf30-8edf38dd873b.png">  |
|    |  <img width="400" alt="max2" src="https://user-images.githubusercontent.com/45976466/200913330-4052e691-b73e-4cd6-afcc-115b2f7040d6.png">  |



### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
