### PR TITLE
Accessibility on MultipleDescriptionView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
 - Add "Dynamic cover carousel" component
+- Se realizan ajustes de accesibilidad en la MultipleDescriptionView para que la moneda sea interpretada como "peso" o "real" por el VoiceOver y no como "dolar".
 
 ## [1.46.0] - 2022-11-09
 ### Changed

--- a/Example/Example_BusinessComponents/MockData/RowData.swift
+++ b/Example/Example_BusinessComponents/MockData/RowData.swift
@@ -35,13 +35,14 @@ class RowData: NSObject, MLBusinessRowData {
                 RowMainDescriptionData(type: "text", content: "598m", color: "#737373"),
                 RowMainDescriptionData(type: "text", content: " · ", color: "#737373"),
                 RowMainDescriptionData(type: "image", content: "https://i.ibb.co/prSV6dY/estrella-android.png", color: "#737373"),
-                RowMainDescriptionData(type: "text", content: "4.3 (24)", color: "#737373"),]
+                RowMainDescriptionData(type: "text", content: "4.3 (24)", color: "#737373"),
+        ]
     }
     
     func getMainSecondaryDescription() -> [MLBusinessMultipleDescriptionModel]? {
         
         return [MLBusinessMultipleDescriptionModel(type: "image", content: "https://i.ibb.co/bWSWDHc/icon-delivery-android.png", color: "#00a650"),
-            MLBusinessMultipleDescriptionModel(type: "text", content: "Envío", color: "#00a650"),
+            MLBusinessMultipleDescriptionModel(type: "text", content: "Compra mínima $ 2.500", color: "#333333"),
             MLBusinessMultipleDescriptionModel(type: "text", content: " · ", color: "#00a650"),
             MLBusinessMultipleDescriptionModel(type: "image", content: "https://i.ibb.co/n8gJqYk/icon-pickup-android.png", color: "#00a650"),
             MLBusinessMultipleDescriptionModel(type: "text", content: "Retiro", color: "#00a650"),]

--- a/Source/Commons/MLBusinessAccessibilityUtils.swift
+++ b/Source/Commons/MLBusinessAccessibilityUtils.swift
@@ -1,0 +1,21 @@
+//
+//  MLBusinessAccessibilityUtils.swift
+//  MLBusinessComponents
+//
+//  Created by Ramiro Castrogiovanni on 28/11/2022.
+//
+
+import Foundation
+
+struct AccessibilityUtils {
+
+    static func formatCurrencyForAccessibility(with string: String) -> String? {
+        if string.contains("R$") {
+            return string.formatRealCurrencyForAccessibility()
+        } else if string.contains("$") {
+            return string.formatPesoCurrencyForAccessibility()
+        } else {
+            return nil
+        }
+    }
+}

--- a/Source/Components/MultipleDescription/MLBusinessMultipleDescriptionView.swift
+++ b/Source/Components/MultipleDescription/MLBusinessMultipleDescriptionView.swift
@@ -90,6 +90,7 @@ public class MLBusinessMultipleDescriptionView: UIView {
         label.textAlignment = .left
         label.text = text
         label.textColor = textColor
+        label.accessibilityLabel = AccessibilityUtils.formatCurrencyForAccessibility(with: text)
 
         if compressible ?? false {
             label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)

--- a/Source/Core/Extensions/String+Extension.swift
+++ b/Source/Core/Extensions/String+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  String+Extension.swift
+//  MLBusinessComponents
+//
+//  Created by Ramiro Castrogiovanni on 28/11/2022.
+//
+
+import Foundation
+
+public extension String {
+    func formatPesoCurrencyForAccessibility() -> String {
+        return self.replacingOccurrences(of: "$", with: "pesos")
+    }
+
+    func formatRealCurrencyForAccessibility() -> String {
+        return self.replacingOccurrences(of: "R$", with: "reais")
+    }
+}


### PR DESCRIPTION
## Descripción

Se realizan ajustes de accesibilidad en la MultipleDescriptionView para que la moneda sea interpretada como "peso" o "real" por el VoiceOver y no como "dolar".

MDS: VSP - Accessibility prices (MP + Instore)

## Tipo:

- [ ] Bugfix
- [X] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

## TestApp
https://user-images.githubusercontent.com/85568138/204386585-31a294ac-1fea-45d0-ae84-fc8ed0340ced.mov

## Discounts Center
https://user-images.githubusercontent.com/85568138/204386639-c79dc913-1a82-4c11-91c5-ee3e78de76c6.mov

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [X] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
