### PR TITLE
FlexCoverCarousel Improves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 ### Modified
-- Se unifica el color del gradiente con respecto del sólido que lo continúa.
-- Se soporta que la card solo tenga imagen 
+- FlexCoverCarousel - Se unifica el color del gradiente con respecto del sólido que lo continúa.
+- FlexCoverCarousel - Se soporta que la card solo tenga imagen 
 
 ## [1.48.0] - 2022-11-30
 ### Modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+### Modified
+- Se unifica el color del gradiente con respecto del sólido que lo continúa.
+- Se soporta que la card solo tenga imagen 
+
 ## [1.48.0] - 2022-11-30
 ### Modified
 - Se realizan ajustes de accesibilidad en la MultipleDescriptionView para que la moneda sea interpretada como "peso" o "real" por el VoiceOver y no como "dolar".

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -156,12 +156,10 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         let color = colorString?.hexaToUIColor()
         let startColor = color?.withAlphaComponent(0)
         let endColor = color?.withAlphaComponent(1)
-        let defaultStartColor = defaultGradientColor
-        let defaultEndColor = defaultGradientColor.withAlphaComponent(1)
         
         gradientLayer.frame = gradientView.bounds
-        gradientLayer.colors = [startColor?.cgColor ?? defaultStartColor,
-                                endColor?.cgColor ?? defaultEndColor]
+        gradientLayer.colors = [startColor?.cgColor ?? defaultGradientColor,
+                                endColor?.cgColor ?? defaultGradientColor.withAlphaComponent(1)]
 
         if gradientLayer.superlayer == nil {
             gradientView.layer.insertSublayer(gradientLayer, at: 0)

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -223,7 +223,8 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
             }
         }
         
-        if let colorString = item.backgroundColor, colorString != "" {
+        if let colorString = item.backgroundColor,
+            !colorString.isEmpty {
             mainCardDefaultHeightConstraint.constant = MLBusinessFlexCoverCarouselItemView.containerHeight
             createGradientView(with: colorString)
             mainCardContainerView.backgroundColor = colorString.hexaToUIColor()

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -152,7 +152,8 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         bottomPillView.isHidden = false
     }
     
-    private func createGradientView(with color: UIColor? ) {
+    private func createGradientView(with colorString: String? ) {
+        let color = colorString.hexaToUIColor()
         let startColor = color?.withAlphaComponent(0)
         let endColor = color?.withAlphaComponent(1)
         let defaultStartColor = defaultGradientColor
@@ -223,9 +224,8 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         }
         
         if let colorString = item.backgroundColor, colorString != "" {
-            let color = colorString.hexaToUIColor()
             mainCardDefaultHeightConstraint.constant = MLBusinessFlexCoverCarouselItemView.containerHeight
-            createGradientView(with: color)
+            createGradientView(with: colorString)
             mainCardContainerView.backgroundColor = color
         } else {
             mainCardDefaultHeightConstraint.constant = 0

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -225,7 +225,6 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         
         if let colorString = item.backgroundColor,
             !colorString.isEmpty {
-            mainCardDefaultHeightConstraint.constant = MLBusinessFlexCoverCarouselItemView.containerHeight
             createGradientView(with: colorString)
             mainCardContainerView.backgroundColor = colorString.hexaToUIColor()
         } else {
@@ -320,6 +319,7 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         mainTitleTopLabel.text = nil
         pillLabel.text = nil
         gradientLayer.superlayer?.sublayers?.remove(at: 0)
+        mainCardDefaultHeightConstraint.constant = MLBusinessFlexCoverCarouselItemView.containerHeight
     }
 }
 

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -153,7 +153,7 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
     }
     
     private func createGradientView(with colorString: String? ) {
-        let color = colorString.hexaToUIColor()
+        let color = colorString?.hexaToUIColor()
         let startColor = color?.withAlphaComponent(0)
         let endColor = color?.withAlphaComponent(1)
         let defaultStartColor = defaultGradientColor
@@ -226,7 +226,7 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         if let colorString = item.backgroundColor, colorString != "" {
             mainCardDefaultHeightConstraint.constant = MLBusinessFlexCoverCarouselItemView.containerHeight
             createGradientView(with: colorString)
-            mainCardContainerView.backgroundColor = color
+            mainCardContainerView.backgroundColor = colorString.hexaToUIColor()
         } else {
             mainCardDefaultHeightConstraint.constant = 0
         }

--- a/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/FlexCoverCarousel/Card/MLBusinessFlexCoverCarouselItemView.swift
@@ -12,6 +12,7 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
     fileprivate enum Layout {}
     static let coverHeight: CGFloat = 104
     static let containerHeight: CGFloat = 56
+    let defaultGradientColor = UIColor(red: 0.122, green: 0.161, blue: 0.239, alpha: 0)
     var imageProvider: MLBusinessImageProvider
     
     private lazy var alphaOverlayView: UIView = {
@@ -108,6 +109,9 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         rightBottomInfo.layer.cornerRadius = 8
         return rightBottomInfo
     }()
+    
+    private lazy var mainCardDefaultHeightConstraint = mainCardContainerView.heightAnchor.constraint(equalToConstant:MLBusinessFlexCoverCarouselItemView.containerHeight)
+    
 
     private func createMainTitleTop(with text: String?, color: String?) {
         guard let mainTitleTopText = text else { return }
@@ -148,12 +152,15 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         bottomPillView.isHidden = false
     }
     
-    private func createGradientView() {
-        let start = UIColor(red: 0.122, green: 0.161, blue: 0.239, alpha: 0)
-        let end = UIColor(red: 0.122, green: 0.161, blue: 0.239, alpha: 1)
+    private func createGradientView(with color: UIColor? ) {
+        let startColor = color?.withAlphaComponent(0)
+        let endColor = color?.withAlphaComponent(1)
+        let defaultStartColor = defaultGradientColor
+        let defaultEndColor = defaultGradientColor.withAlphaComponent(1)
         
         gradientLayer.frame = gradientView.bounds
-        gradientLayer.colors = [start.cgColor, end.cgColor]
+        gradientLayer.colors = [startColor?.cgColor ?? defaultStartColor,
+                                endColor?.cgColor ?? defaultEndColor]
 
         if gradientLayer.superlayer == nil {
             gradientView.layer.insertSublayer(gradientLayer, at: 0)
@@ -215,8 +222,13 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
             }
         }
         
-        if let colorString = item.backgroundColor {
-            mainCardContainerView.backgroundColor =  colorString.hexaToUIColor()
+        if let colorString = item.backgroundColor, colorString != "" {
+            let color = colorString.hexaToUIColor()
+            mainCardDefaultHeightConstraint.constant = MLBusinessFlexCoverCarouselItemView.containerHeight
+            createGradientView(with: color)
+            mainCardContainerView.backgroundColor = color
+        } else {
+            mainCardDefaultHeightConstraint.constant = 0
         }
     
         createMainSection(with: item)
@@ -239,7 +251,6 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         addSubview(coverImageView)
         coverImageView.addSubview(gradientView)
         addSubview(mainCardContainerView)
-        createGradientView()
         addSubview(alphaOverlayView)
         addSubview(bottomPillView)
         bottomPillView.addSubview(pillLabel)
@@ -269,7 +280,7 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
             mainCardContainerView.bottomAnchor.constraint(equalTo: bottomAnchor),
             mainCardContainerView.leadingAnchor.constraint(equalTo: coverImageView.leadingAnchor),
             mainCardContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            mainCardContainerView.heightAnchor.constraint(equalToConstant:MLBusinessFlexCoverCarouselItemView.containerHeight),
+            mainCardDefaultHeightConstraint,
             
             headerContainer.bottomAnchor.constraint(equalTo: mainDescriptionLabel.topAnchor, constant: -4),
             headerContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
@@ -307,6 +318,7 @@ public class MLBusinessFlexCoverCarouselItemView: UIView {
         mainDescriptionLabel.text = nil
         mainTitleTopLabel.text = nil
         pillLabel.text = nil
+        gradientLayer.superlayer?.sublayers?.remove(at: 0)
     }
 }
 


### PR DESCRIPTION
## Descripción

- Se soporta el modo "solo imagen" en las cards de FlexCoverCarousel
- Ahora el color del gradiente puede venir de BE

## Tipo:

- [x] Bugfix
- [x] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
![Simulator Screen Recording - iPhone 13 Pro Max - 2022-12-07 at 11 40 50](https://user-images.githubusercontent.com/96143765/206213746-ccb8f261-3296-44e1-a5b8-dad816d594e0.gif)

