### PR TITLE
[Fix] Default value for MultimediaCover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Fixed
+- Default value multimediaCover en DynamicCoverCarousel.
+
 ## [1.49.1] - 2022-12-26
 ### Added
 - Se agrega soporte para imagenes animadas en DynamicCoverCarousel.

--- a/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Card/MLBusinessDynamicCoverCarouselItemModel.swift
+++ b/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Card/MLBusinessDynamicCoverCarouselItemModel.swift
@@ -21,7 +21,7 @@ public struct MLBusinessDynamicCoverCarouselItemModel: Codable {
     
     public init(backgroundColor: String?,
                 imageHeader: String?,
-                multimediaCover: MLBusinessLiveImagesModel?,
+                multimediaCover: MLBusinessLiveImagesModel? = nil,
                 link: String?,
                 topContent: [MLBusinessDynamicCarouselBadgeModel]?,
                 mainDescriptionLeft: [MLBusinessMultipleDescriptionModel]?,


### PR DESCRIPTION
## Descripción

Se agrega valor por defecto para multimedia_cover para no afectar a otras libs

## Tipo:

- [ ] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
