### PR TITLE
[LIVE-IMAGES] v2 Play/Pause Automatic when cards changes focus status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased] 
+### Added
+- LiveImages cuenta con play/pause de las animacion segun estado de foco del carousel.
+
 ## [1.49.2] - 2022-12-27
 ### Fixed
 - Default value multimediaCover en DynamicCoverCarousel.

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesView.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesView.swift
@@ -11,11 +11,12 @@ import WebKit
 enum MLBusinessLiveImagesState {
     case playing
     case stoped
+    case readyToPlay
 }
 
 protocol MLBusinessLiveImagesHelper {
-    func playAnimation()
-    func stopAnimation()
+    func play()
+    func pause()
 }
 
 class MLBusinessLiveImagesView: UIView {
@@ -60,8 +61,8 @@ class MLBusinessLiveImagesView: UIView {
         addSubview(thumbnailImage)
         addSubview(liveImage)
         
-        liveImage.isHidden = viewModel.shouldHideAnimation(state: liveImageState)
-        thumbnailImage.isHidden =  viewModel.shouldHideThumbnail(state: liveImageState)
+        liveImage.isHidden = true
+        thumbnailImage.isHidden =  false
     }
     
     private func setupConstraints() {
@@ -88,16 +89,24 @@ class MLBusinessLiveImagesView: UIView {
 
 extension MLBusinessLiveImagesView: MLBusinessLiveImagesHelper {
     
-    func playAnimation() {
-        changeState(to: .playing)
+    func play() {
+        viewModel.prepareForPlaying(state: liveImageState)
     }
     
-    func stopAnimation() {
+    func pause() {
         changeState(to: .stoped)
+        transitionView()
     }
 }
 
 extension MLBusinessLiveImagesView: LiveImageViewModelDelegate {
+    
+    func transitionView() {
+        
+        self.thumbnailImage.isHidden = self.viewModel.shouldHideThumbnail(state:self.liveImageState)
+        self.liveImage.isHidden = self.viewModel.shouldHideAnimation(state: self.liveImageState)
+    }
+        
     func setStaticImage(with image: UIImage) {
         thumbnailImage.image = image
     }
@@ -108,18 +117,10 @@ extension MLBusinessLiveImagesView: LiveImageViewModelDelegate {
     
     func changeState(to state: MLBusinessLiveImagesState) {
         liveImageState = state
-        
-        UIView.transition(with: self.liveImage,
-                                      duration: 1,
-                                      options: .transitionCrossDissolve,
-                                      animations: {
-                                        self.thumbnailImage.isHidden = self.viewModel.shouldHideThumbnail(state:self.liveImageState)
-                                        self.liveImage.isHidden = self.viewModel.shouldHideAnimation(state: self.liveImageState)
-                                        },
-                                      completion: nil)
     }
     
     func clear() {
+        liveImageState = .stoped
         thumbnailImage.image = nil
         liveImage.clear()
     }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesView.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesView.swift
@@ -116,7 +116,11 @@ extension MLBusinessLiveImagesView: LiveImageViewModelDelegate {
     }
     
     func changeState(to state: MLBusinessLiveImagesState) {
-        liveImageState = state
+        if liveImageState == .playing && state == .stoped {
+            liveImageState = .readyToPlay
+        } else {
+            liveImageState = state
+        }
     }
     
     func clear() {

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesViewModel.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesViewModel.swift
@@ -40,22 +40,20 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
         delegate?.clear()
         
         if let coverMedia = coverMedia {
-            
             if let thumbnail = coverMedia.getThumbnail(), let url = coverMedia.getMediaLink() {
                 isStaticImage = false
-                loadStaticImage(key: thumbnail)
+                loadImage(key: thumbnail)
                 self.delegate?.setAnimatedImage(with: url)
             }
             
         } else if let cover = cover {
             isStaticImage = true
-            loadStaticImage(key: cover)
+            loadImage(key: cover)
         }
     }
     
-    private func loadStaticImage(key: String) {
+    private func loadImage(key: String) {
         imageProvider.getImage(key: key, completion:{ [weak self] image in
-            
             if let image = image {
                 self?.delegate?.setStaticImage(with: image)
                 self?.delegate?.changeState(to: .stoped)
@@ -78,10 +76,9 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
         }
     }
         
-    private func showAnimatedImage(shouldDelay: Bool) {
+    private func showAnimatedImage(shouldDelay: Bool, delayTime: CGFloat = 1.0) {
         if shouldDelay {
-            let delaySecs = 1.0
-            DispatchQueue.main.asyncAfter(deadline: .now() + delaySecs) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delayTime) {
                 self.startAnimation()
             }
         } else {
@@ -93,5 +90,4 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
         self.delegate?.changeState(to: .playing)
         self.delegate?.transitionView()
     }
-
 }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesViewModel.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesViewModel.swift
@@ -11,24 +11,28 @@ protocol LiveImageViewModelDelegate: AnyObject {
     func setStaticImage(with image: UIImage)
     func setAnimatedImage(with url: String)
     func changeState(to state: MLBusinessLiveImagesState)
+    func transitionView()
     func clear()
 }
 
 protocol MLBusinessLiveImagesViewModelProtocol: AnyObject {
     var imageProvider: MLBusinessImageProvider { get set }
     var delegate: LiveImageViewModelDelegate? { get set }
+    var isStaticImage: Bool { get set }
     func update(coverMedia: MLBusinessLiveImagesModel?, cover: String?)
     func shouldHideThumbnail(state: MLBusinessLiveImagesState) -> Bool
     func shouldHideAnimation(state: MLBusinessLiveImagesState) -> Bool
+    func prepareForPlaying(state: MLBusinessLiveImagesState)
 }
 
 final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol {
-    
+    var isStaticImage: Bool
     var imageProvider: MLBusinessImageProvider
     weak var delegate: LiveImageViewModelDelegate?
     
-    public init(imageProvider: MLBusinessImageProvider? = nil) {
+    public init(imageProvider: MLBusinessImageProvider? = nil, isStaticImage: Bool = true) {
         self.imageProvider = imageProvider ?? MLBusinessURLImageProvider()
+        self.isStaticImage = isStaticImage
     }
     
     func update(coverMedia: MLBusinessLiveImagesModel?, cover: String?) {
@@ -38,26 +42,25 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
         if let coverMedia = coverMedia {
             
             if let thumbnail = coverMedia.getThumbnail(), let url = coverMedia.getMediaLink() {
-                
-                imageProvider.getImage(key: thumbnail, completion: { [weak self] image in
-                    if let image = image {
-                        self?.delegate?.setStaticImage(with: image)
-                    }
-                })
-                
+                isStaticImage = false
+                loadStaticImage(key: thumbnail)
                 self.delegate?.setAnimatedImage(with: url)
             }
             
         } else if let cover = cover {
-                
-            imageProvider.getImage(key: cover, completion:{ [weak self] image in
-                
-                if let image = image {
-                    self?.delegate?.setStaticImage(with: image)
-                    self?.delegate?.changeState(to: .stoped)
-                }
-            })
+            isStaticImage = true
+            loadStaticImage(key: cover)
         }
+    }
+    
+    private func loadStaticImage(key: String) {
+        imageProvider.getImage(key: key, completion:{ [weak self] image in
+            
+            if let image = image {
+                self?.delegate?.setStaticImage(with: image)
+                self?.delegate?.changeState(to: .stoped)
+            }
+        })
     }
     
     func shouldHideThumbnail(state: MLBusinessLiveImagesState) -> Bool {
@@ -67,4 +70,28 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
     func shouldHideAnimation(state: MLBusinessLiveImagesState) -> Bool {
         return !shouldHideThumbnail(state: state)
     }
+    
+    func prepareForPlaying(state: MLBusinessLiveImagesState) {
+        if !isStaticImage {
+            let shouldDelay = state != .readyToPlay
+            showAnimatedImage(shouldDelay: shouldDelay)
+        }
+    }
+        
+    private func showAnimatedImage(shouldDelay: Bool) {
+        if shouldDelay {
+            let delaySecs = 1.0
+            DispatchQueue.main.asyncAfter(deadline: .now() + delaySecs) {
+                self.startAnimation()
+            }
+        } else {
+            startAnimation()
+        }
+    }
+    
+    private func startAnimation() {
+        self.delegate?.changeState(to: .playing)
+        self.delegate?.transitionView()
+    }
+
 }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesWebView.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesWebView.swift
@@ -96,13 +96,7 @@ class MLBusinessLiveImagesWebView: UIView {
     }
     
     func clear() {
-        HTTPCookieStorage.shared.removeCookies(since: Date.distantPast)
-        
-        WKWebsiteDataStore.default().fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
-            records.forEach { record in
-                WKWebsiteDataStore.default().removeData(ofTypes: record.dataTypes, for: [record], completionHandler: {})
-            }
-        }
+        webview.loadHTMLString("", baseURL: nil)
     }
     
 }
@@ -110,7 +104,7 @@ class MLBusinessLiveImagesWebView: UIView {
 extension MLBusinessLiveImagesWebView: WKNavigationDelegate {
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        liveImageDelegate?.changeState(to: .playing)
+        liveImageDelegate?.changeState(to: .readyToPlay)
     }
 }
 

--- a/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Card/MLBusinessDynamicCoverCarouselItemView.swift
+++ b/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Card/MLBusinessDynamicCoverCarouselItemView.swift
@@ -272,3 +272,13 @@ public class MLBusinessDynamicCoverCarouselItemView: UIView {
         backgroundImageView.alpha = alpha
     }
 }
+
+extension MLBusinessDynamicCoverCarouselItemView: MLBusinessLiveImagesHelper {
+    func play() {
+        backgroundImageView.play()
+    }
+    
+    func pause() {
+        backgroundImageView.pause()
+    }
+}

--- a/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Card/MLBusinessDynamicCoverCarouselViewCell.swift
+++ b/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Card/MLBusinessDynamicCoverCarouselViewCell.swift
@@ -87,3 +87,13 @@ class MLBusinessDynamicCoverCarouselViewCell: UICollectionViewCell {
         itemView.update(with: content)
     }
 }
+
+extension MLBusinessDynamicCoverCarouselViewCell: MLBusinessLiveImagesHelper {
+    func play() {
+        itemView.play()
+    }
+    
+    func pause() {
+        itemView.pause()
+    }
+}

--- a/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Carousel/MLBusinessDynamicCoverCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Carousel/MLBusinessDynamicCoverCarouselView.swift
@@ -153,8 +153,8 @@ extension MLBusinessDynamicCoverCarouselView: UICollectionViewDataSource {
         }
         cell.imageProvider = imageProvider
         cell.update(with: content)
-        
-        if indexPath.row == 0 && indexPath.row == collectionViewHelper.currentActiveIndex {
+
+        if indexPath == IndexPath(indexes: [0,1]) && IndexPath(indexes: [0,0]) == IndexPath(indexes: [0,collectionViewHelper.currentActiveIndex]) {
             prepareAnimation()
         }
         

--- a/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Carousel/MLBusinessDynamicCoverCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Carousel/MLBusinessDynamicCoverCarouselView.swift
@@ -19,6 +19,7 @@ public class MLBusinessDynamicCoverCarouselView: UIView {
     private var items: [MLBusinessDynamicCoverCarouselItemModel] { return model?.getItems() ?? [] }
     private var defaultCardWidth: CGFloat = 240
     private var itemHeight: CGFloat = 156
+    private var auxCell: MLBusinessDynamicCoverCarouselViewCell?
     public weak var delegate: MLBusinessDynamicCoverCarouselViewDelegate?
 
     private lazy var collectionViewHelper: CarouselCollectionViewHelper = {
@@ -80,6 +81,7 @@ public class MLBusinessDynamicCoverCarouselView: UIView {
     
     public func update(with model: MLBusinessDynamicCoverCarouselModel?) {
         self.model = model
+        self.auxCell = nil
         configureCard(cardType: model?.getType() ?? "landscape")
         collectionView.reloadData()
     }
@@ -122,6 +124,20 @@ public class MLBusinessDynamicCoverCarouselView: UIView {
         collectionViewHeightConstraint = collectionView.heightAnchor.constraint(equalToConstant: itemHeight)
         collectionViewHeightConstraint?.isActive = true
     }
+    
+    private func prepareAnimation() {
+        let currentIndex = IndexPath(indexes: [0,collectionViewHelper.currentActiveIndex])
+        let currentCell = collectionView.cellForItem(at: currentIndex) as? MLBusinessDynamicCoverCarouselViewCell
+        
+        if let auxCell = auxCell {
+            auxCell.pause()
+            currentCell?.play()
+            self.auxCell = currentCell
+        } else {
+            self.auxCell = currentCell
+            self.auxCell?.play()
+        }
+    }
 }
 
 extension MLBusinessDynamicCoverCarouselView: UICollectionViewDataSource {
@@ -137,6 +153,11 @@ extension MLBusinessDynamicCoverCarouselView: UICollectionViewDataSource {
         }
         cell.imageProvider = imageProvider
         cell.update(with: content)
+        
+        if indexPath.row == 0 && indexPath.row == collectionViewHelper.currentActiveIndex {
+            prepareAnimation()
+        }
+        
         return cell
     }
 }
@@ -150,10 +171,10 @@ extension MLBusinessDynamicCoverCarouselView: UICollectionViewDelegateFlowLayout
 extension MLBusinessDynamicCoverCarouselView: CarouselCollectionViewHelperDelegate {
     func carouselDelegateDidScrollToItem(_ carouselDelegate: CarouselCollectionViewHelper) {
         delegate?.dynamicCoverCarouselView(self, didFinishScrolling: visibleItems)
+        prepareAnimation()
     }
     
     func carouselDelegate(_ carouselDelegate: CarouselCollectionViewHelper, didSelectItemAt indexPath: IndexPath) {
         delegate?.dynamicCoverCarouselView(self, didSelect:items[indexPath.item], at: indexPath.item)
     }
 }
-


### PR DESCRIPTION
## Descripción
Para esta version se implementa play/pause automatica para cuando la card del carousel cambia el estado del foco de la card.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Screenshots - Gifs

| antes `v1` | despues `v2` |
|----|-----|
| ![Simulator Screen Recording - iPhone 13 - 2022-12-16 at 09 50 56](https://user-images.githubusercontent.com/97110592/209865862-86365fd6-0ac6-450f-abfb-f96db3e9fc85.gif) | ![Simulator Screen Recording - iPhone 13 - 2022-12-28 at 17 06 13](https://user-images.githubusercontent.com/97110592/209866545-9b625619-ca4f-4fa1-9203-3cad8aa76a61.gif)|

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
