### PR TITLE
[Live Images] Download + Cache Solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+## Added
+- Manejo de cache para LiveImages
+
 ## [1.51.0] - 2023-01-11
 ### Fixed
 - Issue en LiveImages que hacia que se vean de manera incorrecta algunas animaciones.

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesProvider.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesProvider.swift
@@ -44,7 +44,5 @@ class MLBusinessLiveImagesProvider {
         })
         
         downloadTask.resume()
-    }
-    
-    
+    }  
 }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesProvider.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesProvider.swift
@@ -30,7 +30,9 @@ class MLBusinessLiveImagesProvider {
         let downloadTask = URLSession.shared.dataTask(with: urlRequest, completionHandler: {
             [weak self] data, response, error in
             
-            guard let data = data, error == nil, let response = response, ((response as? HTTPURLResponse)?.statusCode ?? 500) < 300 else {
+            guard let data = data, error == nil,
+                  let response = response as? HTTPURLResponse,
+                  response.statusCode < 300 else {
                 completion(nil)
                 return
             }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesProvider.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesProvider.swift
@@ -21,7 +21,7 @@ class MLBusinessLiveImagesProvider {
             return
         }
         
-        guard let url = URL(string: key)else {
+        guard let url = URL(string: key) else {
             completion(nil)
             return
         }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesProvider.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesProvider.swift
@@ -1,0 +1,48 @@
+//
+//  MLBusinessLiveImagesProvider.swift
+//  MLBusinessComponents
+//
+//  Created by Lautaro Bonasora on 16/01/2023.
+//
+
+import Foundation
+
+class MLBusinessLiveImagesProvider {
+    
+    static let shared = MLBusinessLiveImagesProvider()
+    private let cache = NSCache<NSString, NSData>()
+    
+    public init(){}
+    
+    public func getLiveImageData(from key: String, completion: @escaping (Data?) -> Void) {
+
+        if let data = cache.object(forKey: NSString(string: key)) {
+            completion(data as Data)
+            return
+        }
+        
+        guard let url = URL(string: key)else {
+            completion(nil)
+            return
+        }
+        
+        let urlRequest = URLRequest(url: url)
+        let downloadTask = URLSession.shared.dataTask(with: urlRequest, completionHandler: {
+            [weak self] data, response, error in
+            
+            guard let data = data, error == nil, let response = response, ((response as? HTTPURLResponse)?.statusCode ?? 500) < 300 else {
+                completion(nil)
+                return
+            }
+            
+            DispatchQueue.main.async {
+                self?.cache.setObject(NSData(data: data), forKey: NSString(string: key))
+                completion(data)
+            }
+        })
+        
+        downloadTask.resume()
+    }
+    
+    
+}

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesView.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesView.swift
@@ -12,7 +12,7 @@ enum MLBusinessLiveImagesState {
     case playing
     case stoped
     case readyToPlay
-    case bloqued
+    case blocked
 }
 
 protocol MLBusinessLiveImagesHelper {
@@ -122,7 +122,7 @@ extension MLBusinessLiveImagesView: LiveImageViewModelDelegate {
     }
     
     func clear() {
-        liveImageState = .bloqued
+        liveImageState = .blocked
         thumbnailImage.image = nil
         liveImage.isHidden = true
         liveImage.clear()

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesViewModel.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesViewModel.swift
@@ -41,7 +41,7 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
             if let thumbnail = coverMedia.getThumbnail(), let url = coverMedia.getMediaLink() {
                 loadImage(key: thumbnail)
                 self.delegate?.changeState(to: .stoped)
-                self.delegate?.setAnimatedImage(with: url)
+                loadAnimatedImage(key: url)
             }
             
         } else if let cover = cover {
@@ -54,6 +54,17 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
         imageProvider.getImage(key: key, completion:{ [weak self] image in
             if let image = image {
                 self?.delegate?.setStaticImage(with: image)
+            }
+        })
+    }
+    
+    private func loadAnimatedImage(key: String) {
+        
+        MLBusinessLiveImagesProvider.shared.getLiveImageData(from: key, completion: {
+            [weak self] data in
+            
+            DispatchQueue.main.async {
+                self?.delegate?.setAnimatedImage(with: data?.base64EncodedString() ?? "")
             }
         })
     }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesViewModel.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesViewModel.swift
@@ -45,7 +45,7 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
             }
             
         } else if let cover = cover {
-            self.delegate?.changeState(to: .bloqued)
+            self.delegate?.changeState(to: .blocked)
             loadImage(key: cover)
         }
     }
@@ -64,7 +64,11 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
             [weak self] data in
             
             DispatchQueue.main.async {
-                self?.delegate?.setAnimatedImage(with: data?.base64EncodedString() ?? "")
+                if let dataEncoded = data?.base64EncodedString() {
+                    self?.delegate?.setAnimatedImage(with: dataEncoded)
+                } else {
+                    self?.delegate?.changeState(to: .blocked)
+                }
             }
         })
     }
@@ -74,7 +78,7 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
     }
     
     func prepareForStoping(state: MLBusinessLiveImagesState) {
-        if state != .bloqued {
+        if state != .blocked {
             delayWork?.cancel()
             delegate?.changeState(to: .stoped)
             delegate?.transitionView()
@@ -82,7 +86,7 @@ final class MLBusinessLiveImagesViewModel: MLBusinessLiveImagesViewModelProtocol
     }
     
     func prepareForPlaying(state: MLBusinessLiveImagesState) {
-        if state != .bloqued {
+        if state != .blocked {
             let shouldDelay = state != .readyToPlay
             showAnimatedImage(shouldDelay: shouldDelay)
         }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesWebView.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesWebView.swift
@@ -90,8 +90,10 @@ class MLBusinessLiveImagesWebView: UIView {
           </div>
         </html>
         """
+        
+        let imageDataString = "data:image/webp;base64, \(url)"
 
-        let s = html.replacingOccurrences(of: "[URL]", with: url)
+        let s = html.replacingOccurrences(of: "[URL]", with: imageDataString)
         webview.loadHTMLString(s, baseURL: nil)
     }
     


### PR DESCRIPTION
## Descripción
Se agrega soporte para cachear las imagenes animadas en formato webp y cambiamos el load del webview para que consuma el archivo ya descargado.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
