### PR TITLE
[LIVE IMAGES] Support validation for saving battery and celular data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+## Added
+- (LiveImages) Se agrega validacion para no mostrar imagenes animadas segun estado de bateria y consumo datos.
+
 ## [1.53.0] - 2023-01-26
 ## Changed
 - (LiveImages) Se cambia parte de la arquitectura para que sea consistente en mobile.

--- a/Source/Components/Touchpoints/LiveImages/ImageAnimationManager.swift
+++ b/Source/Components/Touchpoints/LiveImages/ImageAnimationManager.swift
@@ -47,6 +47,7 @@ final class ImageAnimationManager: ImageAnimationManagerProtocol {
     private var delayWork: DispatchWorkItem?
     private var liveImageState: MLBusinessLiveImagesState = .paused
     private var playPending: Bool = false
+    private var model: MLBusinessLiveImagesModel?
         
     private func loadImage(key: String) {
         imageProvider.getImage(key: key, completion:{ [weak self] image in
@@ -94,6 +95,7 @@ final class ImageAnimationManager: ImageAnimationManagerProtocol {
 
     func update(coverMedia: MLBusinessLiveImagesModel?, cover: String?) {
         delegate?.clear()
+        model = coverMedia
         changeState(to: .initMultimedia)
         if let coverMedia = coverMedia,
             let thumbnail = coverMedia.getThumbnail(),

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessBatterySavingUtils.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessBatterySavingUtils.swift
@@ -17,6 +17,6 @@ class MLBusinessBatterySavingUtils {
     }
     
     func setBatteryStatus() {
-        isBatteryLow = UIDevice.current.batteryLevel < 0.2
+        isBatteryLow = UIDevice.current.batteryLevel < 0.15
     }
 }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessBatterySavingUtils.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessBatterySavingUtils.swift
@@ -1,0 +1,22 @@
+//
+//  MLBusinessBatterySavingUtils.swift
+//  MLBusinessComponents
+//
+//  Created by Lautaro Bonasora on 01/02/2023.
+//
+
+import Foundation
+
+class MLBusinessBatterySavingUtils {
+    
+    static let shared = MLBusinessBatterySavingUtils()
+    public private(set) var isBatteryLow = true
+    
+    private init() {
+        UIDevice.current.isBatteryMonitoringEnabled = true
+    }
+    
+    func setBatteryStatus() {
+        isBatteryLow = UIDevice.current.batteryLevel < 0.2
+    }
+}

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesCarousel.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesCarousel.swift
@@ -40,8 +40,6 @@ final class MLBusinessMultimediaCarouselImplementation: MLBusinessMultimediaCaro
     
     func restartFocused(_ position: Int, cell: MLBusinessLiveImagesCellView, positionFocused: Int) {
         startByPosition(position, cell: cell, positionFocused: positionFocused)
-        
-        //TODO: updateConfig()
     }
     
     func pauseFocused() {
@@ -53,6 +51,7 @@ final class MLBusinessMultimediaCarouselImplementation: MLBusinessMultimediaCaro
     }
     
     func updateConfig() {
-        //TODO: WifiUtils and BatteryUtils
+        MLBusinessWifiUtils.shared.startMonitoring()
+        MLBusinessBatterySavingUtils.shared.setBatteryStatus()
     }
 }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesModel.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesModel.swift
@@ -11,10 +11,14 @@ public struct MLBusinessLiveImagesModel: Codable {
     
     private let thumbnail: String?
     private let mediaLink: String?
+    private let mobileData: Bool
+    private let batteryIgnore: Bool
     
-    public init(thumbnail: String?, mediaLink: String?){
+    public init(thumbnail: String?, mediaLink: String?, mobileData: Bool = false, batteryIgnore: Bool = false){
         self.thumbnail = thumbnail
         self.mediaLink = mediaLink
+        self.mobileData = mobileData
+        self.batteryIgnore = batteryIgnore
     }
     
     public func getThumbnail() -> String? {
@@ -23,6 +27,14 @@ public struct MLBusinessLiveImagesModel: Codable {
     
     public func getMediaLink() -> String? {
         return mediaLink
+    }
+    
+    public func shouldIgnoreMobileData() -> Bool {
+        return mobileData
+    }
+    
+    public func shouldIgnoreBattery() -> Bool {
+        return batteryIgnore
     }
 }
 

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesModel.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessLiveImagesModel.swift
@@ -11,10 +11,10 @@ public struct MLBusinessLiveImagesModel: Codable {
     
     private let thumbnail: String?
     private let mediaLink: String?
-    private let mobileData: Bool
-    private let batteryIgnore: Bool
+    private let mobileData: Bool?
+    private let batteryIgnore: Bool?
     
-    public init(thumbnail: String?, mediaLink: String?, mobileData: Bool = false, batteryIgnore: Bool = false){
+    public init(thumbnail: String?, mediaLink: String?, mobileData: Bool? = false, batteryIgnore: Bool? = false){
         self.thumbnail = thumbnail
         self.mediaLink = mediaLink
         self.mobileData = mobileData
@@ -29,11 +29,11 @@ public struct MLBusinessLiveImagesModel: Codable {
         return mediaLink
     }
     
-    public func shouldIgnoreMobileData() -> Bool {
+    public func shouldIgnoreMobileData() -> Bool? {
         return mobileData
     }
     
-    public func shouldIgnoreBattery() -> Bool {
+    public func shouldIgnoreBattery() -> Bool? {
         return batteryIgnore
     }
 }

--- a/Source/Components/Touchpoints/LiveImages/MLBusinessWifiUtils.swift
+++ b/Source/Components/Touchpoints/LiveImages/MLBusinessWifiUtils.swift
@@ -1,0 +1,31 @@
+//
+//  MLBusinessWifiUtils.swift
+//  MLBusinessComponents
+//
+//  Created by Lautaro Bonasora on 27/01/2023.
+//
+
+import Foundation
+import Network
+
+class MLBusinessWifiUtils {
+    static let shared = MLBusinessWifiUtils()
+    private let queue = DispatchQueue.global()
+    private var monitor: NWPathMonitor
+    public private(set) var isWifiNetworkConnected: Bool = false
+    
+    private init() {
+        monitor = NWPathMonitor(requiredInterfaceType: .wifi)
+    }
+    
+    func startMonitoring() {
+        monitor.start(queue: queue)
+        monitor.pathUpdateHandler = { [weak self] path in
+            self?.isWifiNetworkConnected = path.status == .satisfied
+        }
+    }
+    
+    func stopMonitoring() {
+        monitor.cancel()
+    }
+}

--- a/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Carousel/MLBusinessDynamicCoverCarouselView.swift
+++ b/Source/Components/Touchpoints/Types/DynamicCoverCarousel/Carousel/MLBusinessDynamicCoverCarouselView.swift
@@ -84,6 +84,7 @@ public class MLBusinessDynamicCoverCarouselView: UIView {
     public func update(with model: MLBusinessDynamicCoverCarouselModel?) {
         self.model = model
         self.auxCell = nil
+        multimediaCarousel.updateConfig()
         configureCard(cardType: model?.getType() ?? "landscape")
         collectionView.reloadData()
     }


### PR DESCRIPTION
## Descripción

Se agrega validación para no configurar imagenes animadas cuando el device no esta conectado a wifi o tiene poca bateria.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement


## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-ios/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
